### PR TITLE
Feature/insight groups

### DIFF
--- a/app/assets/scripts/components/common/accordion.js
+++ b/app/assets/scripts/components/common/accordion.js
@@ -165,7 +165,7 @@ function AccordionFoldCmp ({
   );
 }
 AccordionFoldCmp.propTypes = {
-  as: T.node,
+  as: T.any,
   id: T.string,
   className: T.string,
   isFoldExpanded: T.bool,

--- a/app/assets/scripts/components/common/layers/layer-no2.js
+++ b/app/assets/scripts/components/common/layers/layer-no2.js
@@ -8,7 +8,7 @@ export default {
   description: 'Acute harm due to NO2 exposure is only likely to arise in occupational settings. Direct exposure to the skin can cause irritations and burns.',
   type: 'raster-timeseries',
   domain: [
-    '2010-10-01',
+    '2019-03-01',
     '2020-03-01'
   ],
   source: {

--- a/app/assets/scripts/components/common/line-chart/chart.js
+++ b/app/assets/scripts/components/common/line-chart/chart.js
@@ -90,7 +90,7 @@ const ChartWrapper = styled(SizeAwareElement)`
 class DataBrowserChart extends React.Component {
   constructor (props) {
     super(props);
-    this.margin = { top: 16, right: 32, bottom: 80, left: 48 };
+    this.margin = { top: 16, right: 32, bottom: 48, left: 48 };
     // Control whether the chart was rendered.
     // The size aware element fires a onChange event once it is rendered
     // But at that time the chart is not ready yet so we can't update the size.

--- a/app/assets/scripts/components/common/line-chart/data-baseline.layer.js
+++ b/app/assets/scripts/components/common/line-chart/data-baseline.layer.js
@@ -1,7 +1,7 @@
 import { css } from 'styled-components';
 
 import { themeVal } from '../../../styles/utils/general';
-import { bisectorPoints, confidenceLines } from './utils';
+import { dataPoints, confidenceLines } from './utils';
 
 const styles = props => css`
   /* Data specific styles */
@@ -59,7 +59,8 @@ export default {
     // Show the bisector point if needed.
     const bisectorPointData = ctx.state.bisecting ? [ctx.state.doc] : [];
     dataSeries.call(
-      bisectorPoints(bisectorPointData)
+      dataPoints(bisectorPointData)
+        .pointClass('bisector-point')
         .x(xScale)
         .y(yScale)
         .yProp('baseline')

--- a/app/assets/scripts/components/common/line-chart/data-series.layer.js
+++ b/app/assets/scripts/components/common/line-chart/data-series.layer.js
@@ -1,7 +1,7 @@
 import { css } from 'styled-components';
 
 import { themeVal } from '../../../styles/utils/general';
-import { bisectorPoints, confidenceLines } from './utils';
+import { dataPoints, confidenceLines } from './utils';
 
 const styles = props => css`
   /* Data specific styles */
@@ -58,7 +58,8 @@ export default {
     // Show the bisector point if needed.
     const bisectorPointData = ctx.state.bisecting ? [ctx.state.doc] : [];
     dataSeries.call(
-      bisectorPoints(bisectorPointData)
+      dataPoints(bisectorPointData)
+        .pointClass('bisector-point')
         .x(xScale)
         .y(yScale)
         .yProp('indicator')

--- a/app/assets/scripts/components/common/line-chart/utils.js
+++ b/app/assets/scripts/components/common/line-chart/utils.js
@@ -2,14 +2,15 @@ import * as d3 from 'd3';
 
 import { utcDate } from '../../../utils/utils';
 
-export function bisectorPoints (data) {
+export function dataPoints (data) {
   let _yprop = 'value';
+  let _klass = null;
   let _x = null;
   let _y = null;
 
   function main (context) {
     const points = context
-      .selectAll('.bisector-point')
+      .selectAll(`.${_klass}`)
       .data(data);
 
     // Remove old.
@@ -19,7 +20,7 @@ export function bisectorPoints (data) {
       .enter()
       .append('circle')
       .attr('r', 4)
-      .attr('class', 'bisector-point')
+      .attr('class', _klass)
       .merge(points)
       // Update current.
       .attr('cx', d => _x(utcDate(d.date)))
@@ -38,6 +39,11 @@ export function bisectorPoints (data) {
 
   main.y = _ => {
     _y = _;
+    return main;
+  };
+
+  main.pointClass = _ => {
+    _klass = _;
     return main;
   };
 

--- a/app/assets/scripts/components/common/panel-block.js
+++ b/app/assets/scripts/components/common/panel-block.js
@@ -18,7 +18,7 @@ export const PanelBlock = styled.section`
 `;
 
 export const PanelBlockHeader = styled.header`
-  box-shadow: 0 1px 0 0 ${themeVal('color.baseAlphaB')};
+  box-shadow: inset 0 -1px 0 0 ${themeVal('color.baseAlphaB')};
   background: ${_tint(0.02, themeVal('color.surface'))};
   position: relative;
   z-index: 10;

--- a/app/assets/scripts/components/spotlight/single/index.js
+++ b/app/assets/scripts/components/spotlight/single/index.js
@@ -86,6 +86,20 @@ const BodyScroll = styled(ShadowScrollbar)`
 
 const PanelBodyInner = styled.div`
   padding: ${glsp()};
+
+  figcaption {
+    margin-bottom: ${glsp(0.5)};
+  }
+
+  > *:not(:last-child) {
+    margin-bottom: ${glsp(2)};
+  }
+`;
+
+const Attribution = styled.p`
+  font-size: 0.874rem;
+  text-align: right;
+  padding-right: ${glsp(2)};
 `;
 
 class SpotlightAreasSingle extends React.Component {
@@ -251,8 +265,10 @@ class SpotlightAreasSingle extends React.Component {
                           const yDomain = ind.domain.indicator;
 
                           return (
-                            <React.Fragment key={ind.id}>
-                              <h2>{ind.name}</h2>
+                            <figure key={ind.id}>
+                              <figcaption>
+                                <h2>{ind.name}</h2>
+                              </figcaption>
                               {ind.description && <p>{ind.description}</p>}
                               <LineChart
                                 xDomain={xDomain}
@@ -265,7 +281,8 @@ class SpotlightAreasSingle extends React.Component {
                                 noBaselineConfidence
                                 noIndicatorConfidence
                               />
-                            </React.Fragment>
+                              {ind.attribution && <Attribution>By: {ind.attribution}</Attribution>}
+                            </figure>
                           );
                         }) : (
                           <p>Detailed information for the area being viewed and/or interacted by the user.</p>

--- a/app/assets/scripts/components/spotlight/single/index.js
+++ b/app/assets/scripts/components/spotlight/single/index.js
@@ -259,6 +259,7 @@ class SpotlightAreasSingle extends React.Component {
                                 yDomain={yDomain}
                                 data={ind.data}
                                 yUnit={ind.units}
+                                selectedDate={!!activeTimeseriesLayers.length && this.state.timelineDate}
                                 highlightBands={ind.highlightBands && ind.highlightBands.length ? ind.highlightBands : null}
                                 noBaseline={ind.data[0].baseline === undefined}
                                 noBaselineConfidence

--- a/app/assets/scripts/components/spotlight/single/index.js
+++ b/app/assets/scripts/components/spotlight/single/index.js
@@ -16,18 +16,16 @@ import {
 } from '../../../styles/inpage';
 import MbMap from '../../common/mb-map-explore/mb-map';
 import UhOh from '../../uhoh';
-import LineChart from '../../common/line-chart/chart';
 import DataLayersBlock from '../../common/data-layers-block';
-import Panel, { PanelHeadline, PanelTitle } from '../../common/panel';
+import Panel, { PanelHeadline } from '../../common/panel';
 import MapMessage from '../../common/map-message';
 import Timeline from '../../common/timeline';
+import SecPanel from './sec-panel';
 
 import { themeVal } from '../../../styles/utils/general';
-import { glsp } from '../../../styles/utils/theme-values';
 import { fetchSpotlightSingle as fetchSpotlightSingleAction } from '../../../redux/spotlight';
 import { wrapApiResult, getFromState } from '../../../redux/reduxeed';
 import { showGlobalLoading, hideGlobalLoading } from '../../common/global-loading';
-import { utcDate } from '../../../utils/utils';
 import allMapLayers from '../../common/layers';
 import {
   setLayerState,
@@ -41,7 +39,6 @@ import {
   toggleLayerRasterTimeseries,
   getActiveTimeseriesLayers
 } from '../../../utils/map-explore-utils';
-import ShadowScrollbar from '../../common/shadow-scrollbar';
 
 const layersBySpotlight = {
   be: ['no2', 'car-count'],
@@ -73,33 +70,6 @@ const ExploreCarto = styled.section`
 
 const PrimePanel = styled(Panel)`
   width: 18rem;
-`;
-
-const SecPanel = styled(Panel)`
-  width: 24rem;
-`;
-
-const BodyScroll = styled(ShadowScrollbar)`
-  flex: 1;
-  z-index: 1;
-`;
-
-const PanelBodyInner = styled.div`
-  padding: ${glsp()};
-
-  figcaption {
-    margin-bottom: ${glsp(0.5)};
-  }
-
-  > *:not(:last-child) {
-    margin-bottom: ${glsp(2)};
-  }
-`;
-
-const Attribution = styled.p`
-  font-size: 0.874rem;
-  text-align: right;
-  padding-right: ${glsp(2)};
 `;
 
 class SpotlightAreasSingle extends React.Component {
@@ -184,7 +154,11 @@ class SpotlightAreasSingle extends React.Component {
 
     if (spotlight.hasError()) return <UhOh />;
 
-    const spotlightData = spotlight.getData();
+    const {
+      label,
+      indicators,
+      indicatorGroups
+    } = spotlight.getData();
     const layers = this.getLayersWithState();
     const activeTimeseriesLayers = this.getActiveTimeseriesLayers();
 
@@ -216,7 +190,7 @@ class SpotlightAreasSingle extends React.Component {
                   onPanelChange={this.resizeMap}
                   headerContent={
                     <PanelHeadline>
-                      <h2>{spotlightData.label}</h2>
+                      <h2>{label}</h2>
                     </PanelHeadline>
                   }
                   bodyContent={
@@ -248,48 +222,12 @@ class SpotlightAreasSingle extends React.Component {
                     onSizeChange={this.resizeMap}
                   />
                 </ExploreCarto>
-                <SecPanel
-                  collapsible
-                  direction='right'
-                  onPanelChange={this.resizeMap}
-                  headerContent={
-                    <PanelHeadline>
-                      <PanelTitle>Insights</PanelTitle>
-                    </PanelHeadline>
-                  }
-                  bodyContent={
-                    <BodyScroll>
-                      <PanelBodyInner>
-                        {spotlightData.indicators.length ? spotlightData.indicators.map(ind => {
-                          const xDomain = ind.domain.date.map(utcDate);
-                          const yDomain = ind.domain.indicator;
 
-                          return (
-                            <figure key={ind.id}>
-                              <figcaption>
-                                <h2>{ind.name}</h2>
-                              </figcaption>
-                              {ind.description && <p>{ind.description}</p>}
-                              <LineChart
-                                xDomain={xDomain}
-                                yDomain={yDomain}
-                                data={ind.data}
-                                yUnit={ind.units}
-                                selectedDate={!!activeTimeseriesLayers.length && this.state.timelineDate}
-                                highlightBands={ind.highlightBands && ind.highlightBands.length ? ind.highlightBands : null}
-                                noBaseline={ind.data[0].baseline === undefined}
-                                noBaselineConfidence
-                                noIndicatorConfidence
-                              />
-                              {ind.attribution && <Attribution>By: {ind.attribution}</Attribution>}
-                            </figure>
-                          );
-                        }) : (
-                          <p>Detailed information for the area being viewed and/or interacted by the user.</p>
-                        )}
-                      </PanelBodyInner>
-                    </BodyScroll>
-                  }
+                <SecPanel
+                  onPanelChange={this.resizeMap}
+                  indicators={indicators}
+                  indicatorGroups={indicatorGroups}
+                  selectedDate={activeTimeseriesLayers.length ? this.state.timelineDate : null}
                 />
               </ExploreCanvas>
             </InpageBody>

--- a/app/assets/scripts/redux/spotlight.js
+++ b/app/assets/scripts/redux/spotlight.js
@@ -15,7 +15,35 @@ export function fetchSpotlightSingle (id) {
     // cache: true,
     statePath: ['spotlight', 'single', id],
     requestFn: spotlightSingleActions.request.bind(null, id),
-    receiveFn: spotlightSingleActions.receive.bind(null, id)
+    receiveFn: spotlightSingleActions.receive.bind(null, id),
+    mutator: (data) => {
+      const indicatorGroups = [
+        {
+          id: 'g1',
+          label: 'Group 1',
+          prose: 'Some description about this data grouping. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Curabitur condimentum rutrum erat. Mauris neque erat, gravida ut orci a, feugiat viverra lacus. Aenean vehicula vitae ex eget varius.',
+          indicators: []
+        },
+        {
+          id: 'g2',
+          label: 'Group 2',
+          prose: 'Some description about this data grouping. Nullam in lectus in nibh mollis rhoncus at eget leo. Nulla lacus nisl, laoreet sit amet dapibus sed, pretium sed est. Duis rutrum faucibus ornare. Suspendisse in nunc ex.',
+          indicators: []
+        }
+      ];
+
+      data.indicators.forEach((ind, i) => {
+        indicatorGroups[i % 2].indicators.push(ind.id);
+      });
+
+      data.indicators[0].attribution = 'Wayne Enterprises';
+      data.indicators[0].prose = 'Some description about this data chart. Neugiat viverra lacus. Aenean vehicula vitae ex eget varius. Amet dapibus sed, pretium sed est. Duis rutrum faucibus ornare.';
+
+      return {
+        ...data,
+        indicatorGroups
+      };
+    }
   });
 }
 


### PR DESCRIPTION
Requires https://github.com/NASA-IMPACT/covid-dashboard/pull/98 to be reviewed/merged first.

This PR adds the Indicator groups to the insights panel.
To minimize the changes to the `indicators` property of the api, the groups are defined in a property called `indicatorGroups` which is an array of objects with the following properties:
- `id`: Group id
- `label`: Group human readable label
- `prose`: Paragraph with with information about the group. Optional.
- `indicators`: Ids of the indicators in this group

Example:
```js
{
  indicatorGroups: [
    {
      id: 'g1',
      label: 'Group 1',
      prose: 'Some description about this data grouping.',
      indicators: ['no2', 'car-count']
    }
  ]
}
```

**Note:** The commit https://github.com/NASA-IMPACT/covid-dashboard/commit/9a1ff05b29d4f4cf605a6451ca545a767cbfada2 contains code to include the dummy code while the api is not ready. This commit will have to be reverted.

Gif:
![groups](https://user-images.githubusercontent.com/1090606/83558842-8a325880-a50b-11ea-9a8f-5eb476b90c02.gif)

### Indicators
Each indicator has now support for a `prose` property which is displayed as a paragraph below the chart.

@olafveerman let me know what you think of this structure
