### PR TITLE
Add spotlights markers

### DIFF
--- a/app/assets/scripts/components/common/mb-map-explore/mb-map.js
+++ b/app/assets/scripts/components/common/mb-map-explore/mb-map.js
@@ -404,7 +404,7 @@ class MbMap extends React.Component {
                 </ul>
               </>
             ) : (
-              <div>This area has no indicators at the moment.</div>
+              <div>There are no indicators for this area at the moment.</div>
             )}
           </Prose>
         }

--- a/app/assets/scripts/components/common/mb-map-explore/mb-map.js
+++ b/app/assets/scripts/components/common/mb-map-explore/mb-map.js
@@ -381,6 +381,7 @@ class MbMap extends React.Component {
         mbMap={this.mbMap}
         lngLat={this.state.popover.coords}
         onClose={() => this.setState({ popover: {} })}
+        offset={[38, 3]}
         suptitle='Area'
         title={
           <SpotlightNavLink

--- a/app/assets/scripts/components/common/mb-map-explore/mb-map.js
+++ b/app/assets/scripts/components/common/mb-map-explore/mb-map.js
@@ -476,4 +476,4 @@ const mapDispatchToProps = {
   fetchSpotlightSingle: fetchSpotlightSingleAction
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(withTheme(MbMap));
+export default connect(mapStateToProps, mapDispatchToProps, null, { forwardRef: true })(withTheme(MbMap));

--- a/app/assets/scripts/components/common/mb-map-explore/mb-map.js
+++ b/app/assets/scripts/components/common/mb-map-explore/mb-map.js
@@ -78,9 +78,7 @@ class MbMap extends React.Component {
       popover: {
         coords: null,
         spotlightId: null
-      },
-      mbMapSpotlightsLoaded: false,
-      mbMapComparingSpotlightsLoaded: false
+      }
     };
   }
 
@@ -202,30 +200,17 @@ class MbMap extends React.Component {
         );
     };
 
-    // As the maps load separately, use component state to verify if they
-    // already loaded the markers
-    const {
-      mbMapSpotlightsLoaded,
-      mbMapComparingSpotlightsLoaded
-    } = this.state;
-
     // Add markers to mbMap, if not done yet
-    if (this.mbMap && !mbMapSpotlightsLoaded) {
+    if (this.mbMap) {
       spotlights.forEach((s) => {
         addMarker(s, this.mbMap);
-      });
-      this.setState({
-        mbMapSpotlightsLoaded: true
       });
     }
 
     // Add markers to mbMapComparing, if not done yet
-    if (this.mbMapComparing && !mbMapComparingSpotlightsLoaded) {
+    if (this.mbMapComparing) {
       spotlights.forEach((s) => {
         addMarker(s, this.mbMapComparing);
-      });
-      this.setState({
-        mbMapComparingSpotlightsLoaded: true
       });
     }
   }

--- a/app/assets/scripts/components/common/mb-map-explore/mb-map.js
+++ b/app/assets/scripts/components/common/mb-map-explore/mb-map.js
@@ -74,6 +74,10 @@ const SingleMapContainer = styled.div`
   bottom: 0;
 `;
 
+const SpotlightIndicatorsHeading = styled(Heading)`
+  margin-bottom: 0.5rem;
+`;
+
 const SpotlightNavLink = styled(NavLink)`
   color: inherit;
 `;
@@ -395,9 +399,9 @@ class MbMap extends React.Component {
           <Prose>
             {indicators && indicators.length > 0 ? (
               <>
-                <Heading as='h2' size='medium'>
+                <SpotlightIndicatorsHeading as='h2' size='medium'>
                   Indicators available
-                </Heading>
+                </SpotlightIndicatorsHeading>
                 <ul>
                   {indicators.map(({ id, name }) => (
                     <li key={id}>{name}</li>

--- a/app/assets/scripts/components/common/mb-map-explore/mb-map.js
+++ b/app/assets/scripts/components/common/mb-map-explore/mb-map.js
@@ -383,8 +383,13 @@ class MbMap extends React.Component {
           </>
         }
         footerContent={
-          <Button element={NavLink} to={`/explore/${spotlight.id}`}>
-            Go to area
+          <Button
+            variation='primary-raised-dark'
+            element={NavLink}
+            to={`/explore/${spotlight.id}`}
+            title={`Visit ${spotlight.label} page`}
+          >
+            Explore area
           </Button>
         }
       />

--- a/app/assets/scripts/components/common/mb-map-explore/mb-map.js
+++ b/app/assets/scripts/components/common/mb-map-explore/mb-map.js
@@ -3,16 +3,17 @@ import T from 'prop-types';
 import styled, { withTheme } from 'styled-components';
 import mapboxgl from 'mapbox-gl';
 import CompareMbGL from 'mapbox-gl-compare';
+import { NavLink } from 'react-router-dom';
 
 import config from '../../../config';
 import { layerTypes } from '../layers/types';
 import { glsp } from '../../../styles/utils/theme-values';
 import mbAoiDraw from './mb-aoi-draw';
 import { round } from '../../../utils/format';
-import ReactPopoverGl from './mb-popover';
 import { createMbMarker } from './mb-popover/utils';
+
+import ReactPopoverGl from './mb-popover';
 import Button from '../../../styles/button/button';
-import { NavLink } from 'react-router-dom';
 
 const {
   center,
@@ -356,11 +357,11 @@ class MbMap extends React.Component {
   }
 
   renderPopover () {
-    const [spotlight] = this.props.spotlightList.getData().filter(
+    const { getData, isReady } = this.props.spotlightList;
+    const spotlightList = isReady() ? getData() : [];
+    const spotlight = spotlightList.find(
       (s) => s.id === this.state.popover.spotlightId
-    );
-
-    if (!spotlight) return null;
+    ) || {};
 
     return (
       <ReactPopoverGl
@@ -412,7 +413,6 @@ class MbMap extends React.Component {
       <>
         {this.props.spotlightList &&
           this.mbMap &&
-          this.state.popover.coords &&
           this.renderPopover()}
         <MapsContainer id='container'>
           <SingleMapContainer

--- a/app/assets/scripts/components/common/mb-map-explore/mb-map.js
+++ b/app/assets/scripts/components/common/mb-map-explore/mb-map.js
@@ -67,6 +67,10 @@ const SingleMapContainer = styled.div`
   bottom: 0;
 `;
 
+const SpotlightNavLink = styled(NavLink)`
+  color: inherit;
+`;
+
 class MbMap extends React.Component {
   constructor (props) {
     super(props);
@@ -364,7 +368,14 @@ class MbMap extends React.Component {
         lngLat={this.state.popover.coords}
         onClose={() => this.setState({ popover: {} })}
         suptitle='Spotlight'
-        title={spotlight.label}
+        title={(
+          <SpotlightNavLink
+            to={`/explore/${spotlight.id}`}
+            title={`Visit ${spotlight.label} page`}
+          >
+            {spotlight.label}
+          </SpotlightNavLink>
+        )}
         content={
           <>
             <div>Minim veniam aliquip exercitation officia in.</div>

--- a/app/assets/scripts/components/common/mb-map-explore/mb-map.js
+++ b/app/assets/scripts/components/common/mb-map-explore/mb-map.js
@@ -476,4 +476,6 @@ const mapDispatchToProps = {
   fetchSpotlightSingle: fetchSpotlightSingleAction
 };
 
-export default connect(mapStateToProps, mapDispatchToProps, null, { forwardRef: true })(withTheme(MbMap));
+export default connect(mapStateToProps, mapDispatchToProps, null, {
+  forwardRef: true
+})(withTheme(MbMap));

--- a/app/assets/scripts/components/common/mb-map-explore/mb-map.js
+++ b/app/assets/scripts/components/common/mb-map-explore/mb-map.js
@@ -18,6 +18,8 @@ import { createMbMarker } from './mb-popover/utils';
 
 import ReactPopoverGl from './mb-popover';
 import Button from '../../../styles/button/button';
+import Heading from '../../../styles/type/heading';
+import Prose from '../../../styles/type/prose';
 
 const {
   center,
@@ -379,7 +381,7 @@ class MbMap extends React.Component {
         mbMap={this.mbMap}
         lngLat={this.state.popover.coords}
         onClose={() => this.setState({ popover: {} })}
-        suptitle='Spotlight'
+        suptitle='Area'
         title={
           <SpotlightNavLink
             to={`/explore/${spotlight.id}`}
@@ -389,18 +391,22 @@ class MbMap extends React.Component {
           </SpotlightNavLink>
         }
         content={
-          indicators && indicators.length > 0 ? (
-            <>
-              <h2>Indicators available</h2>
-              <ul>
-                {indicators.map(({ id, name }) => (
-                  <li key={id}>{name}</li>
-                ))}
-              </ul>
-            </>
-          ) : (
-            <div>This area has no indicators at the moment.</div>
-          )
+          <Prose>
+            {indicators && indicators.length > 0 ? (
+              <>
+                <Heading as='h2' size='medium'>
+                  Indicators available
+                </Heading>
+                <ul>
+                  {indicators.map(({ id, name }) => (
+                    <li key={id}>{name}</li>
+                  ))}
+                </ul>
+              </>
+            ) : (
+              <div>This area has no indicators at the moment.</div>
+            )}
+          </Prose>
         }
         footerContent={
           <Button

--- a/app/assets/scripts/components/common/mb-map-explore/mb-map.js
+++ b/app/assets/scripts/components/common/mb-map-explore/mb-map.js
@@ -21,13 +21,7 @@ import Button from '../../../styles/button/button';
 import Prose from '../../../styles/type/prose';
 import Dl from '../../../styles/type/definition-list';
 
-const {
-  center,
-  zoom: defaultZoom,
-  minZoom,
-  maxZoom,
-  styleUrl
-} = config.map;
+const { center, zoom: defaultZoom, minZoom, maxZoom, styleUrl } = config.map;
 
 // Set mapbox token.
 mapboxgl.accessToken = config.mbToken;
@@ -143,8 +137,8 @@ class MbMap extends React.Component {
     // This leads to problems when finding a given layer in the layers array.
     // We can safely assume that when the layers array change, all the active
     // layers should be hidden.
-    const currId = this.props.layers.map(l => l.id).join('.');
-    const prevIds = prevProps.layers.map(l => l.id).join('.');
+    const currId = this.props.layers.map((l) => l.id).join('.');
+    const prevIds = prevProps.layers.map((l) => l.id).join('.');
     if (currId !== prevIds) {
       this.props.activeLayers.forEach((layerId) => {
         const layerInfo = prevProps.layers.find((l) => l.id === layerId);
@@ -157,7 +151,10 @@ class MbMap extends React.Component {
       });
     }
 
-    if (prevProps.activeLayers !== activeLayers || comparing !== prevProps.comparing) {
+    if (
+      prevProps.activeLayers !== activeLayers ||
+      comparing !== prevProps.comparing
+    ) {
       const toRemove = prevProps.activeLayers.filter(
         (l) => !activeLayers.includes(l)
       );
@@ -265,22 +262,30 @@ class MbMap extends React.Component {
     });
 
     // Add zoom controls.
-    this.mbMapComparing.addControl(new mapboxgl.NavigationControl(), 'top-left');
+    this.mbMapComparing.addControl(
+      new mapboxgl.NavigationControl(),
+      'top-left'
+    );
 
     // Remove compass.
     document.querySelector('.mapboxgl-ctrl .mapboxgl-ctrl-compass').remove();
 
     if (this.props.enableLocateUser) {
-      this.mbMapComparing.addControl(new mapboxgl.GeolocateControl({
-        positionOptions: {
-          enableHighAccuracy: true
-        },
-        trackUserLocation: true
-      }), 'top-left');
+      this.mbMapComparing.addControl(
+        new mapboxgl.GeolocateControl({
+          positionOptions: {
+            enableHighAccuracy: true
+          },
+          trackUserLocation: true
+        }),
+        'top-left'
+      );
     }
 
     // Style attribution.
-    this.mbMapComparing.addControl(new mapboxgl.AttributionControl({ compact: true }));
+    this.mbMapComparing.addControl(
+      new mapboxgl.AttributionControl({ compact: true })
+    );
 
     this.mbMapComparing.once('load', () => {
       this.mbMapComparingLoaded = true;
@@ -288,7 +293,11 @@ class MbMap extends React.Component {
       this.updateSpotlights();
     });
 
-    this.compareControl = new CompareMbGL(this.mbMapComparing, this.mbMap, '#container');
+    this.compareControl = new CompareMbGL(
+      this.mbMapComparing,
+      this.mbMap,
+      '#container'
+    );
   }
 
   updateActiveLayers (prevProps) {
@@ -336,12 +345,15 @@ class MbMap extends React.Component {
       document.querySelector('.mapboxgl-ctrl .mapboxgl-ctrl-compass').remove();
 
       if (this.props.enableLocateUser) {
-        this.mbMap.addControl(new mapboxgl.GeolocateControl({
-          positionOptions: {
-            enableHighAccuracy: true
-          },
-          trackUserLocation: true
-        }), 'top-left');
+        this.mbMap.addControl(
+          new mapboxgl.GeolocateControl({
+            positionOptions: {
+              enableHighAccuracy: true
+            },
+            trackUserLocation: true
+          }),
+          'top-left'
+        );
       }
     }
 
@@ -352,7 +364,11 @@ class MbMap extends React.Component {
     if (this.props.aoiState) {
       this.mbDraw = mbAoiDraw(this.mbMap);
       const { feature } = this.props.aoiState;
-      this.mbDraw.setup(this.props.onAction, feature ? [feature] : null, this.props.theme);
+      this.mbDraw.setup(
+        this.props.onAction,
+        feature ? [feature] : null,
+        this.props.theme
+      );
     }
 
     this.mbMap.on('load', () => {
@@ -472,10 +488,7 @@ class MbMap extends React.Component {
   render () {
     return (
       <>
-        {
-          this.mbMap &&
-          this.renderPopover()
-        }
+        {this.mbMap && this.renderPopover()}
         <MapsContainer id='container'>
           <SingleMapContainer
             ref={(el) => {

--- a/app/assets/scripts/components/common/mb-map-explore/mb-popover/index.js
+++ b/app/assets/scripts/components/common/mb-map-explore/mb-popover/index.js
@@ -1,0 +1,193 @@
+import React from 'react';
+import { PropTypes as T } from 'prop-types';
+import { TransitionGroup, CSSTransition } from 'react-transition-group';
+
+import MBPopoverInner from './popover-inner';
+import { POPOVER_SHOW_HIDE_ANIM_TIME } from './styled';
+
+// Note: This wrapper acts as the entrypoint for the popover mounting and
+// unmouting it when coordinates are removed. This approach helps to deal with
+// setting event listeners and managing animations
+
+/**
+ * Mapbox Popover
+ * An alternative to mapbox popover that is portaled to the body to avoid
+ * clipping due to map and or popover size.
+ * The popover is shown when coordinates are present, if they are currently
+ * within the map viewport.
+ *
+ * The popover has internal mechanisms to hide itself when the map gets clicked
+ * but it is important to remove the coordinates once the popover is hidden.
+ *
+ * @example
+ *  <ReactPopoverGl
+ *    mbMap={mbMap}
+ *    lngLat={this.state.coords}
+ *    onClose={() => this.setState({ coords: null })}
+ * />
+ *
+ * If no overrides are applied, the popover structure is outlined below.
+ * It is listed with styled components and the corresponding html element
+ * in front.
+ * <Popover>                   // article
+ *   <PopoverContents>         // div
+ *     <PopoverHeader>         // header
+ *       <PopoverHeadline>     // div
+ *         <h1></h1>           -- title prop
+ *         <p></p>             -- subtitle or suptitle (see below) prop
+ *       </PopoverHeadline>
+ *       <PopoverToolbar>      // div
+ *         <CloseButton />     // button
+ *       </PopoverToolbar>
+ *     </PopoverHeader>
+ *     <PopoverBody />         // div -- content prop
+ *     <PopoverFooter />       // footer -- footerContent prop
+ *   </PopoverContents>
+ * </Popover>
+ *
+ * The `Popover` and `PopoverContents` are required for positioning and styling
+ * purposes. All other elements can be replaced with render functions.
+ * The code that generates the structure above is:
+ * @example
+ * <ReactPopoverGl
+ *   mbMap={mbMap}
+ *   lngLat={this.state.coords}
+ *   onClose={() => this.setState({ coords: null })}
+ *   title='Popover Title'
+ *   subtitle='Subtitle below'
+ *   content={<p>This is the content</p>}
+ *   footerContent={<p>This is the footer content</p>}
+ * />
+ *
+ * @param {object} mbMap Mapbox map which the popover will use. Required.
+ * @param {array} lngLat Coordinates the popover points to. Required.
+ * @param {function} onClose Callback when the popover is hidden. Required.
+ * @param {bool} closeOnClick Whether or not the popover should close when the
+ *               map gets clicked. Default `true`.
+ * @param {bool} closeOnMove Whether or not the popover should close when the
+ *               map is dragged. Default `false`.
+ * @param {bool} closeButton Whether or not the popover should render
+ *               the default close button. Default `true`.
+ * @param {string} title Title for the popover. Required unless the header is
+ *                 being overridden.
+ * @param {string} subtitle Subtitle for the popover. It is displayed below the
+ *                 title.
+ * @param {string} suptitle Suptitle for the popover. It is displayed above the
+ *                 title. If both subtitle and suptitle are present, the
+ *                 suptitle gets ignored.
+ * @param {node} content Popover body content, rendered inside `PopoverBody`.
+ *               Required unless the body is being overridden.
+ * @param {node} footerContent Popover footer content, rendered
+ *               inside `PopoverFooter`.
+ * @param {array} offset Vertical offset for the popover. The array must have 2
+ *                values. The first for the top offset the second for the
+ *                bottom offset.
+ * @param {function} renderContents Overrides the contents of the popover.
+ *                   Anything returned by this function is rendered inside
+ *                   `PopoverContents`.
+ *                   Signature: fn(bag). Bag has the following props:
+ *                     {function} close Method to close the popover.
+ * @param {function} renderHeader Overrides the popover header element.
+ *                   Anything returned by this function is rendered instead of
+ *                   `PopoverHeader`.
+ *                   Signature: fn(bag). Bag has the following props:
+ *                     {function} close Method to close the popover.
+ * @param {function} renderHeadline Overrides the popover headline element.
+ *                   Anything returned by this function is rendered instead of
+ *                   `PopoverHeadline`.
+ *                   Signature: fn(bag). Bag has the following props:
+ *                     {function} close Method to close the popover.
+ * @param {function} renderToolbar Overrides the popover toolbar element.
+ *                   Anything returned by this function is rendered instead of
+ *                   `PopoverToolbar`.
+ *                   Signature: fn(bag). Bag has the following props:
+ *                     {function} close Method to close the popover.
+ * @param {function} renderBody Overrides the popover body element.
+ *                   Anything returned by this function is rendered instead of
+ *                   `PopoverBody`.
+ *                   Signature: fn(bag). Bag has the following props:
+ *                     {function} close Method to close the popover.
+ * @param {function} renderFooter Overrides the popover footer element.
+ *                   Anything returned by this function is rendered instead of
+ *                   `PopoverFooter`.
+ *                   Signature: fn(bag). Bag has the following props:
+ *                     {function} close Method to close the popover.
+ */
+export default class MBPopover extends React.Component {
+  constructor (props) {
+    super(props);
+
+    this.onClose = this.onClose.bind(this);
+  }
+
+  componentDidUpdate (prevProps) {
+    const { lngLat } = this.props;
+    const pLngLat = prevProps.lngLat;
+
+    // When we're transitioning the popover to a different location we need to
+    // prevent the map click from triggering the close callback or the new
+    // popover will not show up because the coordinates will be cleared on the
+    // parent component.
+    if (pLngLat && lngLat) {
+      const prev = pLngLat.join('-');
+      const curr = lngLat.join('-');
+      if (prev !== curr) {
+        this.switchingPopovers = true;
+      }
+    }
+  }
+
+  onClose () {
+    if (this.switchingPopovers) {
+      this.switchingPopovers = false;
+      return;
+    }
+    this.props.onClose();
+  }
+
+  render () {
+    // Remove unneeded props.
+    const { lngLat, onClose: _, mbMap, ...rest } = this.props;
+
+    if (lngLat && !mbMap) {
+      /* eslint-disable-next-line no-console */
+      console.error('Mapbox map required for the popover. Use the mbMap prop.');
+      return null;
+    }
+
+    return (
+      <TransitionGroup component={null}>
+        {lngLat && (
+          // Ideally we'd use a Transition instead of CSSTransition and handle
+          // the transitions with styled components.
+          // However when the component is mounting there is no reflow between
+          // the exited and entering states and therefore there's no time for
+          // the initial styles to be applied.
+          // The suggestion listed at
+          // https://github.com/reactjs/react-transition-group/issues/223 of
+          // reading a node property onEnter and causing a reflow is not working
+          // in this case. CSSTransition relies on css classes which work
+          // perfectly fine.
+          <CSSTransition
+            key={lngLat.join('-')}
+            timeout={POPOVER_SHOW_HIDE_ANIM_TIME}
+            classNames='popover-gl'
+          >
+            <MBPopoverInner
+              {...rest}
+              mbMap={mbMap}
+              lngLat={lngLat}
+              onClose={this.onClose}
+            />
+          </CSSTransition>
+        )}
+      </TransitionGroup>
+    );
+  }
+}
+
+MBPopover.propTypes = {
+  onClose: T.func,
+  lngLat: T.array,
+  mbMap: T.object
+};

--- a/app/assets/scripts/components/common/mb-map-explore/mb-popover/popover-inner.js
+++ b/app/assets/scripts/components/common/mb-map-explore/mb-popover/popover-inner.js
@@ -262,12 +262,11 @@ export default class MBPopoverInner extends React.Component {
         <Popover
           className={className}
           style={popoverStyle}
-          verticalAttachment={anchorPoints[0]}
           ref={el => {
             this.popoverEl = el;
           }}
         >
-          <PopoverContents anchor={anchor}>
+          <PopoverContents anchor={anchor} verticalAttachment={anchorPoints[0]}>
             {this.renderContents()}
           </PopoverContents>
         </Popover>

--- a/app/assets/scripts/components/common/mb-map-explore/mb-popover/popover-inner.js
+++ b/app/assets/scripts/components/common/mb-map-explore/mb-popover/popover-inner.js
@@ -1,0 +1,308 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { PropTypes as T } from 'prop-types';
+
+import Button from '../../../../styles/button/button';
+import {
+  getAnchorTranslate,
+  Popover,
+  PopoverContents,
+  PopoverHeader,
+  PopoverHeadline,
+  PopoverSubtitle,
+  PopoverToolbar,
+  PopoverBody,
+  PopoverFooter
+} from './styled';
+
+/**
+ * Mapbox popover inner element.
+ * NOT TO BE USED DIRECTLY
+ *
+ * See documentation on index.js file.
+ */
+export default class MBPopoverInner extends React.Component {
+  constructor (props) {
+    super(props);
+
+    this.update = this.update.bind(this);
+    this.destroy = this.destroy.bind(this);
+
+    this.state = {
+      top: null,
+      left: null,
+      // isOutside: true,
+      anchorPoints: []
+    };
+  }
+
+  componentDidMount () {
+    const { mbMap, closeOnClick, closeOnMove } = this.props;
+
+    if (closeOnClick) {
+      mbMap.on('click', this.destroy);
+    }
+    this.update();
+    // Ensure the popover gets repositioned after it has sizes defined.
+    setTimeout(() => {
+      this.update();
+    }, 1);
+
+    if (closeOnMove) {
+      mbMap.on('move', this.destroy);
+    } else {
+      mbMap.on('move', this.update);
+    }
+  }
+
+  componentDidUpdate (prevProps) {
+    if (prevProps.lngLat !== this.props.lngLat) {
+      this.preventNextClick = true;
+      setTimeout(() => {
+        this.preventNextClick = false;
+      }, 1);
+      this.update();
+    }
+  }
+
+  componentWillUnmount () {
+    this.offListeners();
+  }
+
+  offListeners () {
+    const { mbMap } = this.props;
+    mbMap.off('click', this.destroy);
+    mbMap.off('move', this.update);
+    mbMap.off('move', this.destroy);
+  }
+
+  destroy () {
+    this.offListeners();
+    this.props.onClose();
+  }
+
+  update () {
+    if (!this.popoverEl) return;
+
+    const { mbMap, lngLat, offset: [offsetTop, offsetBottom] } = this.props;
+
+    const { pageYOffset, pageXOffset } = window;
+    const {
+      width,
+      height,
+      top,
+      left
+    } = mbMap.getContainer().getBoundingClientRect();
+    const mapTop = pageYOffset + top;
+    const mapLeft = pageXOffset + left;
+    const mapRight = pageXOffset + left + width;
+    const mapBottom = pageYOffset + top + height;
+
+    const pos = mbMap.project(lngLat);
+
+    const anchorPosition = {
+      top: mapTop + pos.y,
+      left: mapLeft + pos.x
+    };
+
+    if (
+      // Top bound
+      anchorPosition.top < mapTop ||
+      // Bottom bound
+      anchorPosition.top > mapBottom ||
+      // Left bound
+      anchorPosition.left < mapLeft ||
+      // Right bound
+      anchorPosition.left > mapRight
+    ) {
+      return this.setState({
+        top: null,
+        left: null,
+        // isOutside: true,
+        anchorPoints: []
+      });
+    }
+
+    let anchorPoints = [];
+
+    const popoverDomRect = this.popoverEl.getBoundingClientRect();
+    const halfW = popoverDomRect.width / 2;
+    if (anchorPosition.top - popoverDomRect.height - offsetTop < pageYOffset) {
+      anchorPoints = ['top'];
+      anchorPosition.top += offsetBottom;
+    } else {
+      anchorPoints = ['bottom'];
+      anchorPosition.top -= offsetTop;
+    }
+    if (anchorPosition.left - halfW < mapLeft) {
+      anchorPoints.push('left');
+    } else if (anchorPosition.left + halfW > mapRight) {
+      anchorPoints.push('right');
+    }
+    this.setState({
+      ...anchorPosition,
+      // isOutside: false,
+      anchorPoints
+    });
+  }
+
+  renderContents () {
+    const { renderContents } = this.props;
+    if (typeof renderContents === 'function') {
+      return renderContents({ close: this.destroy });
+    }
+
+    return (
+      <React.Fragment>
+        {this.renderHeader()}
+        {this.renderBody()}
+        {this.renderFooter()}
+      </React.Fragment>
+    );
+  }
+
+  renderHeader () {
+    const { renderHeader } = this.props;
+    if (typeof renderHeader === 'function') {
+      return renderHeader({ close: this.destroy });
+    }
+
+    return (
+      <PopoverHeader>
+        {this.renderHeadline()}
+        {this.renderToolbar()}
+      </PopoverHeader>
+    );
+  }
+
+  renderHeadline () {
+    const { renderHeadline, title, subtitle, suptitle } = this.props;
+    if (typeof renderHeadline === 'function') {
+      return renderHeadline({ close: this.destroy });
+    }
+
+    return (
+      <PopoverHeadline>
+        <h1>{title}</h1>
+        {(subtitle || suptitle) && (
+          <PopoverSubtitle isSup={!subtitle}>
+            {subtitle || suptitle}
+          </PopoverSubtitle>
+        )}
+      </PopoverHeadline>
+    );
+  }
+
+  renderToolbar () {
+    const { renderToolbar, closeButton } = this.props;
+    if (typeof renderToolbar === 'function') {
+      return renderToolbar({ close: this.destroy });
+    }
+
+    return (
+      closeButton && (
+        <PopoverToolbar>
+          <Button
+            useIcon='xmark--small'
+            size='small'
+            hideText
+            onClick={this.destroy}
+          >
+            Close
+          </Button>
+        </PopoverToolbar>
+      )
+    );
+  }
+
+  renderBody () {
+    const { renderBody, content } = this.props;
+    if (typeof renderBody === 'function') {
+      return renderBody({ close: this.destroy });
+    }
+
+    return (
+      <PopoverBody>
+        {content}
+      </PopoverBody>
+    );
+  }
+
+  renderFooter () {
+    const { renderFooter, footerContent } = this.props;
+    if (typeof renderFooter === 'function') {
+      return renderFooter({ close: this.destroy });
+    }
+
+    return footerContent ? (
+      <PopoverFooter>
+        {footerContent}
+      </PopoverFooter>
+    ) : null;
+  }
+
+  render () {
+    const { top, left, anchorPoints } = this.state;
+    const { className } = this.props;
+
+    const hasPlacement = top !== null && left !== null;
+    const anchor = anchorPoints.join('-');
+
+    const popoverStyle = {
+      transform: hasPlacement
+        ? `${getAnchorTranslate(anchor)} translate(${left}px, ${top}px)`
+        : undefined,
+      display: !hasPlacement ? 'none' : undefined
+    };
+
+    return ReactDOM.createPortal(
+      // This wrapper div is needed because it will receive the css classes from
+      // CSSTransition.
+      <div>
+        <Popover
+          className={className}
+          style={popoverStyle}
+          verticalAttachment={anchorPoints[0]}
+          ref={el => {
+            this.popoverEl = el;
+          }}
+        >
+          <PopoverContents anchor={anchor}>
+            {this.renderContents()}
+          </PopoverContents>
+        </Popover>
+      </div>,
+      document.querySelector('body')
+    );
+  }
+}
+
+MBPopoverInner.propTypes = {
+  onClose: T.func,
+  className: T.string,
+
+  mbMap: T.object,
+  lngLat: T.array,
+  closeOnClick: T.bool,
+  closeOnMove: T.bool,
+  closeButton: T.bool,
+  title: T.string,
+  subtitle: T.string,
+  suptitle: T.string,
+  offset: T.array,
+
+  renderContents: T.func,
+  renderHeader: T.func,
+  renderHeadline: T.func,
+  renderToolbar: T.func,
+  renderBody: T.func,
+  content: T.node,
+  renderFooter: T.func,
+  footerContent: T.node
+};
+
+MBPopoverInner.defaultProps = {
+  closeOnClick: true,
+  closeButton: true,
+  offset: [0, 0]
+};

--- a/app/assets/scripts/components/common/mb-map-explore/mb-popover/popover-inner.js
+++ b/app/assets/scripts/components/common/mb-map-explore/mb-popover/popover-inner.js
@@ -285,7 +285,7 @@ MBPopoverInner.propTypes = {
   closeOnClick: T.bool,
   closeOnMove: T.bool,
   closeButton: T.bool,
-  title: T.string,
+  title: T.node,
   subtitle: T.string,
   suptitle: T.string,
   offset: T.array,

--- a/app/assets/scripts/components/common/mb-map-explore/mb-popover/styled.js
+++ b/app/assets/scripts/components/common/mb-map-explore/mb-popover/styled.js
@@ -111,7 +111,7 @@ const getTransition = (isShowing) => {
 };
 
 export const Popover = styled.article`
-  max-width: 20rem;
+  width: 16rem;
   padding: 0.75rem 0;
   position: absolute;
   top: 0;

--- a/app/assets/scripts/components/common/mb-map-explore/mb-popover/styled.js
+++ b/app/assets/scripts/components/common/mb-map-explore/mb-popover/styled.js
@@ -1,7 +1,8 @@
 import styled, { css } from 'styled-components';
 
 import { themeVal } from '../../../../styles/utils/general';
-import { _rgba, glsp } from '../../../../styles/utils/theme-values';
+import { glsp } from '../../../../styles/utils/theme-values';
+import { headingAlt } from '../../../../styles/type/heading';
 
 export const POPOVER_SHOW_HIDE_ANIM_TIME = 240;
 
@@ -184,12 +185,7 @@ export const PopoverHeadline = styled.div`
 
 export const PopoverSubtitle = styled.p`
   order: ${({ isSup }) => isSup ? -1 : 1};
-  font-feature-settings: "pnum" 0; /* Use proportional numbers */
-  font-family: ${themeVal('type.base.family')};
-  font-weight: ${themeVal('type.heading.light')};
-  color: ${_rgba(themeVal('color.base'), 0.64)};
-  font-size: 0.875rem;
-  line-height: 1rem;
+  ${headingAlt()}
 `;
 
 export const PopoverToolbar = styled.div`

--- a/app/assets/scripts/components/common/mb-map-explore/mb-popover/styled.js
+++ b/app/assets/scripts/components/common/mb-map-explore/mb-popover/styled.js
@@ -1,0 +1,214 @@
+import styled, { css } from 'styled-components';
+
+import { themeVal } from '../../../../styles/utils/general';
+import { _rgba, glsp } from '../../../../styles/utils/theme-values';
+
+export const POPOVER_SHOW_HIDE_ANIM_TIME = 240;
+
+const applyBorderStyles = () => ({ anchor }) => {
+  return {
+    'top-left': css`
+      border-top-left-radius: 0;
+    `,
+    'top-right': css`
+      border-top-right-radius: 0;
+    `,
+    'bottom-left': css`
+      border-bottom-left-radius: 0;
+    `,
+    'bottom-right': css`
+      border-bottom-right-radius: 0;
+    `
+  }[anchor];
+};
+
+const applyAnchorStyles = () => ({ anchor }) => {
+  const centerClip = 'clip-path: polygon(50% 0, 0% 100%, 100% 100%);';
+  const cornerClip = 'clip-path: polygon(0 0, 0% 100%, 100% 100%);';
+
+  if (anchor === 'top' || anchor === 'bottom') {
+    const common = css`
+      ${centerClip}
+      left: 50%;
+      width: 1.5rem;
+      height: 0.75rem;
+    `;
+    if (anchor === 'top') {
+      return css`
+        ${common}
+        top: -0.75rem;
+        transform: translate(-50%, 0);
+      `;
+    }
+    if (anchor === 'bottom') {
+      return css`
+        ${common}
+        bottom: -0.75rem;
+        transform: scaleY(-1) translate(-50%, 0);
+      `;
+    }
+  } else {
+    const common = css`
+      ${cornerClip}
+      width: 0.75rem;
+      height: 0.75rem;
+    `;
+
+    if (anchor === 'top-left') {
+      return css`
+        ${common}
+        top: -0.75rem;
+        left: 0;
+      `;
+    }
+    if (anchor === 'top-right') {
+      return css`
+        ${common}
+        top: -0.75rem;
+        right: 0;
+        transform: scaleX(-1);
+      `;
+    }
+    if (anchor === 'bottom-left') {
+      return css`
+        ${common}
+        bottom: -0.75rem;
+        left: 0;
+        transform: scaleY(-1);
+      `;
+    }
+    if (anchor === 'bottom-right') {
+      return css`
+        ${common}
+        bottom: -0.75rem;
+        right: 0;
+        transform: scaleX(-1) scaleY(-1);
+      `;
+    }
+  }
+};
+
+export const getAnchorTranslate = pos =>
+  ({
+    center: 'translate(-50%,-50%)',
+    top: 'translate(-50%,0)',
+    'top-left': 'translate(0,0)',
+    'top-right': 'translate(-100%,0)',
+    bottom: 'translate(-50%,-100%)',
+    'bottom-left': 'translate(0,-100%)',
+    'bottom-right': 'translate(-100%,-100%)',
+    left: 'translate(0,-50%)',
+    right: 'translate(-100%,-50%)'
+  }[pos]);
+
+const getTransition = (isShowing) => {
+  const easing = isShowing
+    ? 'cubic-bezier(0.175, 0.885, 0.32, 1.275)' // easeOutBack
+    : 'cubic-bezier(0.6, -0.28, 0.735, 0.045)'; // easeInBack
+  return css`
+    transition: transform ${POPOVER_SHOW_HIDE_ANIM_TIME}ms ${easing}, opacity ${POPOVER_SHOW_HIDE_ANIM_TIME}ms ease-in-out;
+  `;
+};
+
+export const Popover = styled.article`
+  max-width: 20rem;
+  padding: 0.75rem 0;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 99999;
+`;
+
+export const PopoverContents = styled.div`
+  border-radius: ${themeVal('shape.rounded')};
+  background: ${themeVal('color.surface')};
+  box-shadow: 0 0 32px 2px ${themeVal('color.mist')}, 0 16px 48px -16px ${themeVal('color.shadow')};
+  padding: ${glsp()};
+  transform: scale(1);
+  transform-origin: center ${({ verticalAttachment: va }) => va === 'top' ? 'top' : 'bottom'};
+
+  ${applyBorderStyles()}
+
+  &::before {
+    content: '';
+    position: absolute;
+    background: #fff;
+
+    ${applyAnchorStyles()}
+  }
+
+  > *:last-child {
+    margin-bottom: 0;
+  }
+
+  .popover-gl-enter & {
+    ${getTransition(true)}
+    transform: scale(0);
+    opacity: 0;
+  }
+
+  .popover-gl-enter-active & {
+    transform: scale(1);
+    opacity: 1;
+  }
+
+  .popover-gl-exit & {
+    ${getTransition(false)}
+    transform: scale(1);
+    opacity: 1;
+  }
+
+  .popover-gl-exit-active & {
+    transform: scale(0);
+    opacity: 0;
+  }
+`;
+
+export const PopoverHeader = styled.header`
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: flex-start;
+  margin-bottom: ${glsp()};
+`;
+
+export const PopoverHeadline = styled.div`
+  display: flex;
+  flex-flow: column nowrap;
+
+  h1 {
+    font-size: 1.25rem;
+    line-height: 1.75rem;
+    margin: 0;
+  }
+`;
+
+export const PopoverSubtitle = styled.p`
+  order: ${({ isSup }) => isSup ? -1 : 1};
+  font-feature-settings: "pnum" 0; /* Use proportional numbers */
+  font-family: ${themeVal('type.base.family')};
+  font-weight: ${themeVal('type.heading.light')};
+  color: ${_rgba(themeVal('color.base'), 0.64)};
+  font-size: 0.875rem;
+  line-height: 1rem;
+`;
+
+export const PopoverToolbar = styled.div`
+  margin-left: auto;
+  display: flex;
+  align-items: flex-start;
+  padding: ${glsp(1 / 8)} 0 ${glsp(1 / 8)} ${glsp()};
+`;
+
+export const PopoverBody = styled.div`
+  margin-bottom: ${glsp()};
+
+  > *:not(:last-child) {
+    margin-bottom: ${glsp()};
+  }
+`;
+
+export const PopoverFooter = styled.footer`
+  > *:not(:last-child) {
+    margin-bottom: ${glsp()};
+  }
+`;

--- a/app/assets/scripts/components/common/mb-map-explore/mb-popover/styled.js
+++ b/app/assets/scripts/components/common/mb-map-explore/mb-popover/styled.js
@@ -122,7 +122,7 @@ export const Popover = styled.article`
 export const PopoverContents = styled.div`
   border-radius: ${themeVal('shape.rounded')};
   background: ${themeVal('color.surface')};
-  box-shadow: 0 0 32px 2px ${themeVal('color.mist')}, 0 16px 48px -16px ${themeVal('color.shadow')};
+  box-shadow: 0 0 32px 2px ${themeVal('color.baseAlphaA')}, 0 16px 48px -16px ${themeVal('color.baseAlphaB')};
   padding: ${glsp()};
   transform: scale(1);
   transform-origin: center ${({ verticalAttachment: va }) => va === 'top' ? 'top' : 'bottom'};

--- a/app/assets/scripts/components/common/mb-map-explore/mb-popover/utils.js
+++ b/app/assets/scripts/components/common/mb-map-explore/mb-popover/utils.js
@@ -37,6 +37,7 @@ export const createMbMarker = (map, opt) => {
   mk.remove = () => {
     markerRemove.apply(mk);
     map.off('click', onMapClick);
+    map.off('touchend', onMapClick);
     return mk;
   };
 
@@ -44,6 +45,7 @@ export const createMbMarker = (map, opt) => {
   mk.addTo = (m) => {
     makerAdd.call(mk, m);
     map.on('click', onMapClick);
+    map.on('touchend', onMapClick);
     mk._element.style.cursor = 'pointer';
     return mk;
   };

--- a/app/assets/scripts/components/common/mb-map-explore/mb-popover/utils.js
+++ b/app/assets/scripts/components/common/mb-map-explore/mb-popover/utils.js
@@ -1,0 +1,57 @@
+import mapboxgl from 'mapbox-gl';
+
+/**
+ * Creates a new mapbox marker which supports a click listener.
+ * All the other api methods are the same as mapbox's marker.
+ *
+ * @example
+ * Use:
+ *  createMbMarker(mbMap, opt)
+ *    .setLngLat([-77.03, 38.90])
+ *    .addTo(mbMap)
+ *    .onClick((coords) => {})
+ *
+ * Instead of:
+ *  new mapboxgl.Marker(opt)
+ *    .setLngLat([-77.03, 38.90])
+ *    .addTo(mbMap)
+ *
+ * @param {object} map Mapbox ma instance.
+ * @param {object} opt Mapbox marker options as defined in the documentation.
+ */
+export const createMbMarker = (map, opt) => {
+  const mk = new mapboxgl.Marker(opt);
+  let onClickListener = () => {}; // noop
+
+  const onMapClick = e => {
+    const targetElement = e.originalEvent.target;
+    const element = mk._element;
+
+    if (targetElement === element || element.contains(targetElement)) {
+      const { lng, lat } = mk._lngLat;
+      onClickListener([lng, lat]);
+    }
+  };
+
+  const markerRemove = mk.remove;
+  mk.remove = () => {
+    markerRemove.apply(mk);
+    map.off('click', onMapClick);
+    return mk;
+  };
+
+  const makerAdd = mk.addTo;
+  mk.addTo = (m) => {
+    makerAdd.call(mk, m);
+    map.on('click', onMapClick);
+    mk._element.style.cursor = 'pointer';
+    return mk;
+  };
+
+  mk.onClick = fn => {
+    onClickListener = fn;
+    return mk;
+  };
+
+  return mk;
+};

--- a/app/assets/scripts/components/global/index.js
+++ b/app/assets/scripts/components/global/index.js
@@ -395,6 +395,7 @@ class GlobalExplore extends React.Component {
                   aoiState={this.state.aoi}
                   comparing={isComparing}
                   enableLocateUser
+                  spotlightList={spotlightList}
                 />
                 <Timeline
                   isActive={!!activeTimeseriesLayers.length}

--- a/app/assets/scripts/styles/type/definition-list.js
+++ b/app/assets/scripts/styles/type/definition-list.js
@@ -5,6 +5,8 @@ import { themeVal } from '../utils/general';
 import { headingAlt } from './heading';
 
 const Dl = styled.dl`
+  font-feature-settings: "pnum" 0; /* Use proportional numbers */
+
   dt {
     ${headingAlt()}
     margin: 0 0 ${divide(themeVal('layout.space'), 4)} 0;


### PR DESCRIPTION
See #156. This is a work in progress, current status is:

- Display spotlight markers using API data
- Show custom popover, populated with spotlight title and mock content
- "Go to area" navigation button

To do:

- [x] Review custom marker implementation @danielfdsilva
- [x] Add styles @ricardoduplos 
- [x] Populate with real content @olafveerman 