### PR TITLE
Add comparable CO2.

### DIFF
--- a/app/assets/scripts/components/common/layers/layer-co2.js
+++ b/app/assets/scripts/components/common/layers/layer-co2.js
@@ -1,4 +1,4 @@
-import { format, sub } from 'date-fns';
+import { format } from 'date-fns';
 
 import config from '../../../config';
 
@@ -24,7 +24,7 @@ export default {
     enabled: true,
     help: 'Compare with baseline',
     yearDiff: 0,
-    mapLabel: date => `${format(sub(date, { years: 1 }), "MMM yy''")} — ${format(date, "MMM yy''")}`,
+    mapLabel: date => `Base - Mean (${format(date, "dd MMM yy''")})`,
     source: {
       type: 'raster',
       tiles: [

--- a/app/assets/scripts/components/common/layers/layer-co2.js
+++ b/app/assets/scripts/components/common/layers/layer-co2.js
@@ -1,3 +1,5 @@
+import { format, sub } from 'date-fns';
+
 import config from '../../../config';
 
 export default {
@@ -18,6 +20,19 @@ export default {
   },
   exclusiveWith: ['no2', 'co2-diff', 'gibs-population', 'car-count', 'nightlights-viirs', 'nightlights-hd', 'detection-ship', 'detection-multi', 'water-chlorophyll', 'water-spm'],
   enabled: false,
+  compare: {
+    enabled: true,
+    help: 'Compare with baseline',
+    yearDiff: 0,
+    mapLabel: date => `${format(sub(date, { years: 1 }), "MMM yy''")} — ${format(date, "MMM yy''")}`,
+    source: {
+      type: 'raster',
+      tiles: [
+      `${config.api}/{z}/{x}/{y}@1x?url=s3://covid-eo-data/xco2/xco2_15day_base.{date}.tif&resampling_method=bilinear&bidx=1&rescale=0.0004%2C0.00042`
+      ]
+    }
+  },
+
   swatch: {
     color: '#7E7E7E',
     name: 'Grey'

--- a/app/assets/scripts/components/common/layers/types.js
+++ b/app/assets/scripts/components/common/layers/types.js
@@ -74,7 +74,7 @@ export const layerTypes = {
   'raster-timeseries': {
     update: (ctx, layerInfo, prevProps) => {
       const { mbMap, mbMapComparing, mbMapComparingLoaded, props } = ctx;
-      const { id, source } = layerInfo;
+      const { id, source, compare } = layerInfo;
       const prevLayerInfo = prevProps.layers.find(l => l.id === layerInfo.id);
       const { date, comparing } = props;
 
@@ -107,11 +107,14 @@ export const layerTypes = {
 
       // Update/init compare layer tiles.
       if (comparing) {
-        const source5years = prepSource(layerInfo, source, sub(date, { years: 5 }), knobPos);
+        const sourceCompare = prepSource(layerInfo,
+          compare.source || source,
+          sub(date, { years: compare.yearDiff === undefined ? 5 : compare.yearDiff }),
+          knobPos);
         if (mbMapComparing.getSource(id)) {
-          replaceRasterTiles(mbMapComparing, id, source5years.tiles);
+          replaceRasterTiles(mbMapComparing, id, sourceCompare.tiles);
         } else {
-          mbMapComparing.addSource(id, source5years);
+          mbMapComparing.addSource(id, sourceCompare);
           mbMapComparing.addLayer(
             {
               id: id,


### PR DESCRIPTION
Adds optional / parameters to compare properties for source and year
differential.

#218 

please note: The map will display an incorrect label that we are comparing 1 year in the past. The baseline files are named as `*_base.<2020 date>`, so im not sure what the actual date is. So as far as `types.js` logic is concerned, we are subtracting `yearDiff = 0` years when adding the compare source.