### PR TITLE
Update popover positioning on content change

### DIFF
--- a/app/assets/scripts/components/common/mb-map-explore/mb-popover/popover-inner.js
+++ b/app/assets/scripts/components/common/mb-map-explore/mb-popover/popover-inner.js
@@ -56,7 +56,10 @@ export default class MBPopoverInner extends React.Component {
   }
 
   componentDidUpdate (prevProps) {
-    if (prevProps.lngLat !== this.props.lngLat) {
+    if (
+      prevProps.lngLat !== this.props.lngLat ||
+      prevProps.content !== this.props.content
+    ) {
       this.preventNextClick = true;
       setTimeout(() => {
         this.preventNextClick = false;


### PR DESCRIPTION
The popover is being rendered outside the window if the spolight is localed near to the edge. Example:

![spotlight2](https://user-images.githubusercontent.com/329694/85271210-66ab5f80-b472-11ea-8fa7-2deb4020c2d4.gif)

This is happening after the request for spotlight data is completed and popover content gets a new height. I added a commit to recalculate positioning on content change. 