### PR TITLE
Pre-render metatags

### DIFF
--- a/app/assets/scripts/components/common/meta-tags.js
+++ b/app/assets/scripts/components/common/meta-tags.js
@@ -5,7 +5,7 @@ import { Helmet } from 'react-helmet';
 import theme from '../../styles/theme/theme';
 
 import config from '../../config';
-const { environment, baseUrl, appTitle } = config;
+const { environment, baseUrl, appTitle, twitterHandle } = config;
 
 const MetaTags = ({ title, description, children }) => {
   return (
@@ -18,7 +18,7 @@ const MetaTags = ({ title, description, children }) => {
 
       {/* Twitter */}
       <meta name='twitter:card' content='summary' />
-      <meta name='twitter:site' content='@NASAEarthData' />
+      <meta name='twitter:site' content={twitterHandle} />
       <meta name='twitter:title' content={title} />
       {description ? (
         <meta name='twitter:description' content={description} />

--- a/app/assets/scripts/config/production.js
+++ b/app/assets/scripts/config/production.js
@@ -1,15 +1,19 @@
-export default {
-  environment: 'production',
-  appTitle: 'COVID-19 Dashboard',
-  appDescription: 'Although NASA can&apos;t see the novel #coronavirus from space, we can see how our response to it affects the environment. Explore the data using our new experimental dashboard.',
-  gaTrackingCode: 'UA-170089104-1',
-  mbToken: 'pk.eyJ1IjoiY292aWQtbmFzYSIsImEiOiJja2F6eHBobTUwMzVzMzFueGJuczF6ZzdhIn0.8va1fkyaWgM57_gZ2rBMMg',
-  api: 'https://8ib71h0627.execute-api.us-east-1.amazonaws.com/v1',
-  map: {
-    center: [0, 0],
-    zoom: 2,
-    minZoom: 1,
-    maxZoom: 20,
-    styleUrl: 'mapbox://styles/covid-nasa/ckb01h6f10bn81iqg98ne0i2y'
+// module exports is required to be able to load from gulpfile.
+module.exports = {
+  default: {
+    environment: 'production',
+    appTitle: 'COVID-19 Dashboard',
+    appDescription: 'Although NASA can&apos;t see the novel #coronavirus from space, we can see how our response to it affects the environment. Explore the data using our new experimental dashboard.',
+    gaTrackingCode: 'UA-170089104-1',
+    twitterHandle: '@NASAEarthData',
+    mbToken: 'pk.eyJ1IjoiY292aWQtbmFzYSIsImEiOiJja2F6eHBobTUwMzVzMzFueGJuczF6ZzdhIn0.8va1fkyaWgM57_gZ2rBMMg',
+    api: 'https://8ib71h0627.execute-api.us-east-1.amazonaws.com/v1',
+    map: {
+      center: [0, 0],
+      zoom: 2,
+      minZoom: 1,
+      maxZoom: 20,
+      styleUrl: 'mapbox://styles/covid-nasa/ckb01h6f10bn81iqg98ne0i2y'
+    }
   }
 };

--- a/app/index.html
+++ b/app/index.html
@@ -8,6 +8,22 @@
     <link rel='icon' type='image/png' sizes='192x192' href='{{baseurl}}/assets/graphics/meta/android-chrome.png' />
     <link rel='apple-touch-icon' sizes='180x180' href='{{baseurl}}/assets/graphics/meta/apple-touch-icon.png' />
 
+    <title>{{appTitle}}</title>
+    <meta name='description' content='{{appDescription}}' />
+
+    <meta name='twitter:card' content='summary' />
+    <meta name='twitter:site' content='{{twitterHandle}}' />
+    <meta name='twitter:title' content='{{appTitle}}' />
+    <meta name='twitter:description' content='{{appDescription}}' />
+    <meta name='twitter:image:src' content='{{baseurl}}/assets/graphics/meta/default-meta-image.png' />
+
+    <meta property='og:type' content='website' />
+    <meta property='og:url' content='{{baseurl}}' />
+    <meta property='og:site_name' content='{{appTitle}}' />
+    <meta property='og:title' content='{{appTitle}}' />
+    <meta property='og:image' content='{{baseurl}}/assets/graphics/meta/default-meta-image.png' />
+    <meta property='og:description' content='{{appDescription}}' />
+
     <!-- build:css /assets/styles/vendor.css -->
     <link rel='stylesheet' href='../node_modules/mapbox-gl/dist/mapbox-gl.css' />
     <link rel='stylesheet' href='../node_modules/@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.css' />

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,6 +14,12 @@ const through2 = require('through2');
 
 const { compile: collecticonsCompile } = require('collecticons-processor');
 
+const {
+  appTitle,
+  appDescription,
+  twitterHandle
+} = require('./app/assets/scripts/config/production').default;
+
 // /////////////////////////////////////////////////////////////////////////////
 // --------------------------- Variables -------------------------------------//
 // ---------------------------------------------------------------------------//
@@ -71,7 +77,10 @@ function serve () {
         // Replace the baseUrl placeholder on runtime.
         match: /{{baseurl}}/g,
         replace: ''
-      }
+      },
+      { match: /{{appTitle}}/g, replace: appTitle },
+      { match: /{{appDescription}}/g, replace: appDescription },
+      { match: /{{twitterHandle}}/g, replace: twitterHandle }
     ]
   });
 
@@ -233,6 +242,9 @@ function html () {
     // Add a prefix to all replacements so next line catches them.
     .pipe($.revRewrite({ prefix: '{{baseurl}}' }))
     .pipe($.replace('{{baseurl}}', baseurl))
+    .pipe($.replace('{{appTitle}}', appTitle))
+    .pipe($.replace('{{appDescription}}', appDescription))
+    .pipe($.replace('{{twitterHandle}}', twitterHandle))
     .pipe(gulp.dest('dist'));
 }
 


### PR DESCRIPTION
Fix #149

Not all validators and platforms render an SPA before scraping the data.
By pre-rendering the metatags this gets fixed 