### PR TITLE
Deploy feature branches to surge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,6 @@ jobs:
           name: Build app
           command: |
             yarn build
-            # BASEURL="https://earthdata.nasa.gov/covid19" yarn build
       - persist_to_workspace:
           root: ~/repo
           paths:
@@ -99,6 +98,20 @@ jobs:
             --cache-control "max-age=86400"
           from: /workspace/dist
           to: 's3://covid-eo'
+  deploy-surge:
+    <<: *base_def
+    steps:
+      - checkout
+      - restore_cache:
+          <<: *restore_cache_def
+      - attach_workspace:
+          at: /workspace
+      - run:
+          name: Deploy to surge
+          command: |
+            cp /workspace/dist/index.html /workspace/dist/200.html
+            DOMAIN=$(echo $CIRCLE_BRANCH | cut -c9-)
+            ./node_modules/surge/lib/cli.js --project /workspace/dist --domain covideo-${DOMAIN}.surge.sh
 
 workflows:
   version: 2
@@ -131,3 +144,9 @@ workflows:
           filters:
             branches:
               only: master
+      - deploy-surge:
+          requires:
+            - build
+          filters:
+            branches:
+              only: /feature\/.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
           name: Deploy to surge
           command: |
             cp /workspace/dist/index.html /workspace/dist/200.html
-            DOMAIN=$(echo $CIRCLE_BRANCH | cut -c9-)
+            DOMAIN=$(echo $CIRCLE_BRANCH | cut -c7-)
             ./node_modules/surge/lib/cli.js --project /workspace/dist --domain covideo-${DOMAIN}.surge.sh
 
 workflows:
@@ -149,4 +149,4 @@ workflows:
             - build
           filters:
             branches:
-              only: /feature\/.*/
+              only: /stage\/.*/


### PR DESCRIPTION
Every time a feature branch is pushed to github, it gets deployed to surge, with the following url:
`covideo-<branch-name>.surge.sh`

Where `branch-name` is the name given to the branch after `feature/`. This branch `feature/circle` can be seen at http://covideo-circle.surge.sh/.

There's a bit of a cleanup problem with this. Given that everything we do is under a feature branch, this will result in a lot of deploys. I'll monitor this, and remove deploys of merged branches once in a while.

Should we use something else rather than `feature` for the deploy prefix? This would give us more control, but we'd need to name (or rename) branches knowing that we want them deployed