### PR TITLE
Add simple map layers to stories [ci skip]

### DIFF
--- a/app/assets/scripts/components/stories/index.js
+++ b/app/assets/scripts/components/stories/index.js
@@ -16,7 +16,7 @@
 import air from './story-air';
 import climate from './story-climate';
 import lcluc from './story-lcluc';
-import water from './story-water'
+import water from './story-water';
 
 const stories = [
   air,

--- a/app/assets/scripts/components/stories/story-air.js
+++ b/app/assets/scripts/components/stories/story-air.js
@@ -19,7 +19,7 @@ export default {
         type: 'map-layer',
         data: {
           layers: ['no2-diff'],
-          date: '01/03/20'
+          date: '2020-03-01T00:00:00Z'
         }
       }
     },

--- a/app/assets/scripts/components/stories/story-air.js
+++ b/app/assets/scripts/components/stories/story-air.js
@@ -14,7 +14,14 @@ export default {
             When governments began implementing lockdowns at the start of the COVID-19 pandemic, scientists wondered how the atmosphere would respond to the sudden change in human behavior. With people largely confined to their homes to slow the spread of the virus, there were likely to be fewer cars, planes, and ships burning and emitting fossil fuels. Nearly a year into the pandemic, these scenarios have largely played out: during the strictest lockdown periods, locations around the world experienced substantial reductions in transportation-related fossil fuel emissions. However, those declines have ultimately proven to be short-lived, and the impacts on specific air pollutants have been varied. Today, air quality levels are beginning to approach pre-pandemic levels, and scientists are just beginning to dive into the new measurements collected throughout this unprecedented time.
           </p>
         </>
-      )
+      ),
+      visual: {
+        type: 'map-layer',
+        data: {
+          layers: ['no2-diff'],
+          date: '01/03/20'
+        }
+      }
     },
     {
       id: 'what-makes-aq-good-or-bad',
@@ -92,7 +99,13 @@ export default {
             NASA is able to observe global nitrogen dioxide levels using the OMI instrument (pronounced OH-me) aboard the Aura satellite. A joint endeavor between NASA and the Royal Netherlands Meteorological Institute (KNMI), OMI has been taking continuous global measurements of nitrogen dioxide since 2004. So, when the pandemic hit, OMI was ready to observe subsequent changes in NO<sub>2</sub> levels, and it continues to capture these measurements throughout various stages of the pandemic. NASA scientists are also leveraging other space-based instruments from international partners to study NO<sub>2</sub>. Specifically, the TROPOMI instrument aboard the European Commission’s Copernicus Sentinel-5P satellite helps us see nitrogen dioxide levels in greater detail. TROPOMI and OMI measurements make a great team: TROPOMI provides higher spatial resolution data than OMI, but OMI’s longer data record provides crucial context for TROPOMI observations.
           </p>
         </>
-      )
+      ),
+      visual: {
+        type: 'map-layer',
+        data: {
+          layers: ['no2']
+        }
+      }
     },
     {
       id: 'reinforcing-measurements-nighttime-lights',

--- a/app/assets/scripts/components/stories/story-climate.js
+++ b/app/assets/scripts/components/stories/story-climate.js
@@ -30,7 +30,7 @@ export default {
         type: 'map-layer',
         data: {
           layers: ['co2-diff'],
-          date: '01/03/20'
+          date: '2020-03-01T00:00:00Z'
         }
       }
     },

--- a/app/assets/scripts/components/stories/story-climate.js
+++ b/app/assets/scripts/components/stories/story-climate.js
@@ -25,7 +25,14 @@ export default {
             At the peak of initial pandemic-related shutdowns, cities experienced significant reductions in fossil fuel use compared to previous years. This was largely due to ordinances that asked large portions of the population to stay at home. As a result of these measures, there were fewer cars on the road, planes in the sky, and ships at sea, and business and industrial activity was significantly curtailed, leading to far fewer fossil fuel emissions. Estimates based on global fossil fuel consumption from the Global Carbon Project confirmed these reductions. However, while NASA scientists could easily detect decreases in other fossil fuel combustion byproducts from space, such as nitrogen dioxide, corresponding reductions in carbon dioxide were not as readily apparent. It took much careful analysis to produce the map shown here, depicting global carbon dioxide changes in March 2020, at the height of the initial onset of the pandemic in the United States.
           </p>
         </>
-      )
+      ),
+      visual: {
+        type: 'map-layer',
+        data: {
+          layers: ['co2-diff'],
+          date: '01/03/20'
+        }
+      }
     },
     {
       id: 'difference-between-co2-no2',
@@ -36,7 +43,13 @@ export default {
             Unlike nitrogen dioxide, which is chemically destroyed in the atmosphere a few hours after being emitted, carbon dioxide can last for centuries. This allows it to be transported far from its emission source by winds and causes it to be mixed with the surrounding air to produce a smooth global distribution pattern, such as the one seen here. Atmospheric carbon dioxide concentrations only vary by a few percent over the entire planet – from about 408 to 419 parts per million (ppm). This makes it very difficult to discern the impact of temporary changes in emissions during coronavirus-related shutdowns, as scientists expected that any observed fluctuations would be no larger than 0.1%. Teasing out the impacts of reductions in carbon dioxide emissions for specific locations required the ingenuity of NASA and its partners in the Japan Aerospace Exploration Agency (JAXA), along with advanced modeling, and the development of new analysis techniques.
           </p>
         </>
-      )
+      ),
+      visual: {
+        type: 'map-layer',
+        data: {
+          layers: ['c02']
+        }
+      }
     },
     {
       id: 'co2-natural-carbon-cycle',
@@ -111,7 +124,13 @@ export default {
             The research is also providing new insights into the types of sensors and analysis tools needed to track changes in carbon dioxide from space. These capabilities will be increasingly important as society seeks to decarbonize economies. Results of these COVID-related studies will benefit development of several next-generation satellites launching in the next few years, including Japan’s GOSAT-GW satellite, the Copernicus CO2M constellation, and NASA’s GeoCarb, the first geostationary greenhouse gas satellite.
           </p>
         </>
-      )
+      ),
+      visual: {
+        type: 'map-layer',
+        data: {
+          layers: ['co2-diff']
+        }
+      }
     }
   ]
 };

--- a/app/assets/scripts/components/stories/story-lcluc.js
+++ b/app/assets/scripts/components/stories/story-lcluc.js
@@ -92,6 +92,6 @@ export default {
           </p>
         </>
       )
-    },
+    }
   ]
 };

--- a/app/assets/scripts/components/stories/story-water.js
+++ b/app/assets/scripts/components/stories/story-water.js
@@ -31,7 +31,7 @@ export default {
         type: 'map-layer',
         data: {
           layers: ['no2-diff'],
-          date: '01/03/20'
+          date: '2020-03-01T00:00:00Z'
         }
       }
     },
@@ -60,8 +60,8 @@ export default {
         type: 'map-layer',
         data: {
           layers: ['water-wq-gl-chl'],
-          date: '01/04/20',
-          bbox: [ -84.3695, 45.2013, -81.7492, 41.2530 ]
+          date: '2020-04-01T00:00:00Z',
+          bbox: [-84.3695, 45.2013, -81.7492, 41.2530]
         }
       }
     },
@@ -88,7 +88,7 @@ export default {
       contentComp: (
         <>
           <p>
-            COVID-19 lockdown policies have also made it harder for officials from the U.S. Department of Agriculture (USDA) to travel to farms and collect information about crop planting, progress, and conditions like adequate soil moisture. Especially in cases where ground data is inaccessible, information provided by Earth observing satellites has been critical to filling in agricultural data gaps. Hannah Kerner, an assistant research professor at the University of Maryland in College Park, and her team at NASA Harvest are using satellite data from the joint NASA-U.S. Geological Survey Landsat satellite, the ESA (the European Space Agency) Copernicus Sentinel-2 satellite, and the NASA Moderate Resolution Imaging Spectroradiometer (MODIS) instruments aboard its Terra and Aqua satellites to help supplement USDA’s information. They are also using commercial partner Planet’s high-resolution, space-based imagery. "We're using satellite data and machine learning to map where and which crops are growing," Kerner said. Specifically, they’re monitoring key commodity crops that have high impacts on markets and food security, including corn and soybeans in the U.S. (pictured here) and winter wheat in Russia.
+            COVID-19 lockdown policies have also made it harder for officials from the U.S. Department of Agriculture (USDA) to travel to farms and collect information about crop planting, progress, and conditions like adequate soil moisture. Especially in cases where ground data is inaccessible, information provided by Earth observing satellites has been critical to filling in agricultural data gaps. Hannah Kerner, an assistant research professor at the University of Maryland in College Park, and her team at NASA Harvest are using satellite data from the joint NASA-U.S. Geological Survey Landsat satellite, the ESA (the European Space Agency) Copernicus Sentinel-2 satellite, and the NASA Moderate Resolution Imaging Spectroradiometer (MODIS) instruments aboard its Terra and Aqua satellites to help supplement USDA’s information. They are also using commercial partner Planet’s high-resolution, space-based imagery. &quot;We&apos;re using satellite data and machine learning to map where and which crops are growing,&quot; Kerner said. Specifically, they’re monitoring key commodity crops that have high impacts on markets and food security, including corn and soybeans in the U.S. (pictured here) and winter wheat in Russia.
           </p>
         </>
       )

--- a/app/assets/scripts/components/stories/story-water.js
+++ b/app/assets/scripts/components/stories/story-water.js
@@ -26,7 +26,14 @@ export default {
             California was one of the first places in the United States to impose COVID-19 related restrictions. A shelter-in-place mandate went into effect for six counties in the San Francisco metropolitan area on March 17, 2020. NASA scientists are using satellite data to investigate the connection between observed changes in air quality during this time and water quality. Nitrogen compounds, commonly found in air pollutants, can contribute to the formation of algal blooms in water and also cause water bodies to become more acidic. Remote sensing observations have shown both the clearing of air and improvements in water quality during lockdowns, said Nima Pahlevan, a remote sensing scientist at NASA’s Goddard Space Flight Center. His research is using satellite data to detect anomalies in levels of algae (chlorophyll-a) and total suspended solids across multiple sites, including the San Francisco Bay. The lessons learned from this work will help inform similar work in other coastal cities at global scales.
           </p>
         </>
-      )
+      ),
+      visual: {
+        type: 'map-layer',
+        data: {
+          layers: ['no2-diff'],
+          date: '01/03/20'
+        }
+      }
     },
     {
       id: 'examining-the-chesapeake',
@@ -48,7 +55,15 @@ export default {
             Researchers are using NASA’s ocean color satellites to observe similar changes in water quality within the Great Lakes region. The Great Lakes is home to about 8% of the U.S. population, and the region produces approximately $14.5 billion in agricultural sales each year. From April to June 2020, researchers observed slight increases in chlorophyll and suspended sediment concentrations in the Western Basin of Lake Erie, the portion of the lake most affected by humans and agriculture, compared to the baseline average from 2010 to 2019. However, scientists are still unsure whether these changes are due to COVID-19 related behavioral changes, since they still fall within the historical range of chlorophyll and suspended sediment levels in the lake. Research is ongoing to determine what effects may be seen in the Great Lakes during the COVID-19 pandemic.
           </p>
         </>
-      )
+      ),
+      visual: {
+        type: 'map-layer',
+        data: {
+          layers: ['water-wq-gl-chl'],
+          date: '01/04/20',
+          bbox: [ -84.3695, 45.2013, -81.7492, 41.2530 ]
+        }
+      }
     },
     {
       id: 'glamrous-tool',
@@ -59,7 +74,13 @@ export default {
             As we’ve seen, agriculture and water are inherently linked. However, during this time, scientists are not only examining agriculture’s impact on water quality, but also using remote sensing tools to ensure crops have adequate access to water and other key nutrients during social distancing measures. To do this, new groups have begun leveraging the Group on Earth Observations Global Agricultural Monitoring (GEOGLAM) tool. Typically used to increase agricultural market transparency and bolster food security by producing timely, actionable information on agricultural conditions, GEOGLAM has been used during the pandemic to safely monitor and track agricultural conditions when local curfews and stay-at-home orders have prevented people from performing these duties on the ground. For example, the Togolese government has used GEOGLAM during the pandemic to safely track agricultural conditions throughout the country and distribute much-needed aid to small farmers.
           </p>
         </>
-      )
+      ),
+      visual: {
+        type: 'map-layer',
+        data: {
+          layers: ['geoglam']
+        }
+      }
     },
     {
       id: 'counting-crops',


### PR DESCRIPTION
This PR adds configuration for the simple map layers to the stories.

## Visual
I propose we add an object (`visual`) to each chapter. If a chapter has sections, it is added to the section. At the moment, I've only added the simple map layers to the stories.

``` js
      visual: {
        type: 'map-layer',
        data: {
          layers: ['water-chlorophyll'],
          date: '2020-10-01T00:00:00Z',
          bbox: [ 23.1, 98.1, 78.56, -45.32 ]
        }
      }
```

## Docs
* `type` - the type of visualization. Supported types:  
  * `map-layer` - a basic map layer that shows one or more data products available through the API, for a particular date and location. The user can interact with the data by panning and zooming the map.
* `data.layers` - the `id` of the dataset. Example: `['no2-diff']`
* `data.date` - the date of the scene. To fetch a monthly product, request the first day of the month. If not specified, it will default to the most recent imagery available. Example: `'2020-10-01T00:00:00Z'`
* `data.bbox` - the bounding box to zoom to. If not specified, it will show the whole world. Example: `[ 3.64539683, 51.06663625, 3.858333337, 51.28873095 ]`

## Next steps
Once this is confirmed, there are a couple of other visualization types that we could focus on. These account for roughly 

* `map-compare` - the before / after slider, with data coming from our API.
* `map-layer-tms` / * `map-compare-tms` - map layers pulled from external TMS layer. Maybe these are not separate types, but 
