### PR TITLE
Comparison for stories

### DIFF
--- a/app/assets/scripts/components/common/layers/index.js
+++ b/app/assets/scripts/components/common/layers/index.js
@@ -50,17 +50,14 @@ export function getGlobalLayers () {
 }
 
 export const storeSpotlightLayers = (spotlightId, layers) => {
-  if (spotlightId === 'global') {
-    layersDataBySpotlight[spotlightId] = layers;
-    return;
-  }
-
   // Overrides to the layer settings.
   const spotLayers = layers
     .map((layer) => {
-      const overrides = layerOverrides.find(l => l.id === layer.id) || {};
+      const base = layerOverrides.find(l => l.id === layer.id) || {};
 
-      return defaultsDeep(layer, overrides);
+      // The local changes are the default, and are replaced by new properties
+      // that come from the api. The local updates will always take precedence.
+      return defaultsDeep({}, base, layer);
     });
 
   layersDataBySpotlight[spotlightId] = spotLayers;

--- a/app/assets/scripts/components/common/layers/layer-co2.js
+++ b/app/assets/scripts/components/common/layers/layer-co2.js
@@ -9,8 +9,8 @@ export default {
   compare: {
     enabled: true,
     help: 'Compare with baseline',
-    yearDiff: 0,
     mapLabel: date => `${format(date, 'dd MMM yyyy')}: Base vs Mean`,
+    compareDate: date => date,
     source: {
       type: 'raster',
       tiles: [

--- a/app/assets/scripts/components/common/layers/layer-no2.js
+++ b/app/assets/scripts/components/common/layers/layer-no2.js
@@ -1,4 +1,4 @@
-import { format } from 'date-fns';
+import { format, sub } from 'date-fns';
 
 import config from '../../../config';
 
@@ -8,9 +8,9 @@ export default {
   enabled: true,
   compare: {
     enabled: true,
-    help: 'Compare with baseline (5 previous years)',
+    help: 'Compare with baseline (2 previous years)',
     mapLabel: date => `Baseline vs ${format(date, 'MMM yyyy')}`,
-    yearDiff: 2,
+    compareDate: date => sub(date, { years: 2 }),
     timeUnit: 'monthOnly',
     source: {
       type: 'raster',

--- a/app/assets/scripts/components/common/layers/types.js
+++ b/app/assets/scripts/components/common/layers/types.js
@@ -111,10 +111,18 @@ export const layerTypes = {
 
       // Update/init compare layer tiles.
       if (comparing) {
-        const sourceCompare = prepSource({ ...layerInfo, ...compare },
+        const compareDate =
+          typeof compare.compareDate === 'function'
+            ? compare.compareDate(date)
+            // Default compare date is 5y ago.
+            : sub(date, { years: 5 });
+
+        const sourceCompare = prepSource(
+          { ...layerInfo, ...compare },
           compare.source || source,
-          sub(date, { years: compare.yearDiff === undefined ? 5 : compare.yearDiff }),
-          knobPos);
+          compareDate,
+          knobPos
+        );
         if (mbMapComparing.getSource(id)) {
           replaceRasterTiles(mbMapComparing, id, sourceCompare.tiles);
         } else {

--- a/app/assets/scripts/components/common/layers/types.js
+++ b/app/assets/scripts/components/common/layers/types.js
@@ -10,7 +10,9 @@ const dateFormats = {
 const prepDateSource = (source, date, timeUnit = 'month') => {
   return {
     ...source,
-    tiles: source.tiles.map((t) => t.replace('{date}', format(date, dateFormats[timeUnit])))
+    tiles: source.tiles.map((t) =>
+      t.replace('{date}', format(date, dateFormats[timeUnit]))
+    )
   };
 };
 
@@ -79,7 +81,7 @@ export const layerTypes = {
     update: (ctx, layerInfo, prevProps) => {
       const { mbMap, mbMapComparing, mbMapComparingLoaded, props } = ctx;
       const { id, source, compare, paint } = layerInfo;
-      const prevLayerInfo = prevProps.layers.find(l => l.id === layerInfo.id);
+      const prevLayerInfo = prevProps.layers.find((l) => l.id === layerInfo.id);
       const { date, comparing } = props;
 
       const knobPos = layerInfo.knobCurrPos;
@@ -88,14 +90,15 @@ export const layerTypes = {
       // Do not update if:
       if (
         // There's no date defined.
-        prevProps.date && date &&
+        prevProps.date &&
+        date &&
         // Dates are the same
         date.getTime() === prevProps.date.getTime() &&
         // Knob position for gamma correction is the same.
         knobPos === knobPosPrev &&
         // Compare didn't change.
         comparing === prevProps.comparing
-      ) return;
+      ) { return; }
 
       // The source we're updating is not present.
       if (!mbMap.getSource(id)) return;
@@ -155,7 +158,10 @@ export const layerTypes = {
       if (mbMap.getSource(id)) {
         mbMap.setLayoutProperty(id, 'visibility', 'visible');
       } else {
-        mbMap.addSource(id, prepSource(layerInfo, source, date, layerInfo.knobCurrPos));
+        mbMap.addSource(
+          id,
+          prepSource(layerInfo, source, date, layerInfo.knobCurrPos)
+        );
         mbMap.addLayer(
           {
             id: id,
@@ -207,24 +213,27 @@ export const layerTypes = {
       // Do not update if:
       if (
         // There's no date defined.
-        prevProps.date && date &&
+        prevProps.date &&
+        date &&
         // Dates are the same
         date.getTime() === prevProps.date.getTime()
-      ) return;
+      ) { return; }
 
       // The source we're updating is not present.
       if (!mbMap.getSource(vecId) || !mbMap.getSource(rastId)) return;
       const formatDate = format(date, dateFormats[layerInfo.timeUnit]);
       const vectorData = source.data.replace('{date}', formatDate);
-      const rasterTiles = backgroundSource.tiles.map(tile => tile.replace('{date}', formatDate));
+      const rasterTiles = backgroundSource.tiles.map((tile) =>
+        tile.replace('{date}', formatDate)
+      );
 
       // inference data moves around, recenter on each update
       fetch(vectorData)
-        .then(res => res.json())
-        .then(geo => {
+        .then((res) => res.json())
+        .then((geo) => {
           mbMap.fitBounds(bbox(geo));
         })
-        .catch(err => {
+        .catch((err) => {
           console.log(err); // eslint-disable-line no-console
         });
 
@@ -265,18 +274,27 @@ export const layerTypes = {
       };
       const rasterL = {
         ...backgroundSource,
-        tiles: backgroundSource.tiles.map(tile => tile.replace('{date}', formatDate))
+        tiles: backgroundSource.tiles.map((tile) =>
+          tile.replace('{date}', formatDate)
+        )
       };
 
-      toggleOrAddLayer(mbMap, vecId, vectorL, 'line', inferPaint, 'admin-0-boundary-bg');
+      toggleOrAddLayer(
+        mbMap,
+        vecId,
+        vectorL,
+        'line',
+        inferPaint,
+        'admin-0-boundary-bg'
+      );
       toggleOrAddLayer(mbMap, rastId, rasterL, 'raster', {}, vecId);
 
       fetch(vectorL.data)
-        .then(res => res.json())
-        .then(geo => {
+        .then((res) => res.json())
+        .then((geo) => {
           mbMap.fitBounds(bbox(geo));
         })
-        .catch(err => {
+        .catch((err) => {
           console.log(err); // eslint-disable-line no-console
         });
     }

--- a/app/assets/scripts/components/common/layers/types.js
+++ b/app/assets/scripts/components/common/layers/types.js
@@ -183,7 +183,9 @@ export const layerTypes = {
       // Do not update if:
       if (
         // Compare didn't change.
-        comparing === prevProps.comparing
+        comparing === prevProps.comparing ||
+        // There's no comparing map.
+        !mbMapComparing
       ) { return; }
 
       // If we're comparing, and the compare map is not loaded.

--- a/app/assets/scripts/components/common/layers/types.js
+++ b/app/assets/scripts/components/common/layers/types.js
@@ -175,6 +175,37 @@ export const layerTypes = {
     }
   },
   raster: {
+    update: (ctx, layerInfo, prevProps) => {
+      const { mbMapComparing, mbMapComparingLoaded, props } = ctx;
+      const { id, compare, paint } = layerInfo;
+      const { comparing } = props;
+
+      // Do not update if:
+      if (
+        // Compare didn't change.
+        comparing === prevProps.comparing
+      ) { return; }
+
+      // If we're comparing, and the compare map is not loaded.
+      if (comparing && !mbMapComparingLoaded) return;
+
+      // END update checks.
+
+      if (mbMapComparing.getSource(id)) {
+        mbMapComparing.setLayoutProperty(id, 'visibility', 'visible');
+      } else {
+        mbMapComparing.addSource(id, compare.source);
+        mbMapComparing.addLayer(
+          {
+            id: id,
+            type: 'raster',
+            source: id,
+            paint: paint || {}
+          },
+          'admin-0-boundary-bg'
+        );
+      }
+    },
     hide: (ctx, layerInfo) => {
       const { mbMap } = ctx;
       const { id } = layerInfo;

--- a/app/assets/scripts/components/common/mb-map-explore/mb-map.js
+++ b/app/assets/scripts/components/common/mb-map-explore/mb-map.js
@@ -258,7 +258,7 @@ class MbMap extends React.Component {
   updateSpotlights () {
     // Check if spotlights are available
     const { spotlightList } = this.props;
-    if (!spotlightList && !spotlightList.isReady()) return;
+    if (!spotlightList || !spotlightList.isReady()) return;
 
     // Get spotlights from API data
     const spotlights = spotlightList.getData();

--- a/app/assets/scripts/components/common/mb-map-explore/mb-map.js
+++ b/app/assets/scripts/components/common/mb-map-explore/mb-map.js
@@ -437,18 +437,19 @@ class MbMap extends React.Component {
     }
 
     this.mbMap.on('load', () => {
-      this.props.onAction('map.loaded');
+      const allProps = this.props;
+      const { spotlightList, comparing, onAction } = allProps;
+      onAction('map.loaded');
 
-      if (this.props.comparing) {
+      if (comparing) {
         // Fake previous props to simulate the enabling of the compare option.
         this.enableCompare({
-          ...this.props,
+          ...allProps,
           comparing: false
         });
       }
 
       // If spotlight list is available on map mount, add it to the map
-      const { spotlightList } = this.props;
       if (spotlightList && spotlightList.isReady()) {
         this.updateSpotlights(spotlightList.getData());
       }

--- a/app/assets/scripts/components/stories/single/index.js
+++ b/app/assets/scripts/components/stories/single/index.js
@@ -289,7 +289,16 @@ class StoriesSingle extends React.Component {
         section: [, section]
       } = this.getChapterAndSection();
 
-      this.updateItemVisuals(section || chapter);
+      const currItem = section || chapter;
+      const currVisType = get(currItem, 'visual.type');
+
+      // If the visual type changes to a non map value we have to reset the map
+      // loaded state.
+      if (currVisType !== 'map-layer') {
+        this.setState({ mapLoaded: false });
+      }
+
+      this.updateItemVisuals(currItem);
     }
   }
 
@@ -546,7 +555,7 @@ If this is a system layer, check that a compare property is defined. In alternat
     const [sectionIdx, section] = findById(chapter.sections, sectionId);
     if (sectionId && !section) return <UhOh />;
 
-    const currItem = chapter || section;
+    const currItem = section || chapter;
     const prevItem = getPreviousItem(story.chapters, chapterIdx, sectionIdx);
     const nextItem = getNextItem(story.chapters, chapterIdx, sectionIdx);
 

--- a/app/assets/scripts/components/stories/single/index.js
+++ b/app/assets/scripts/components/stories/single/index.js
@@ -654,6 +654,7 @@ If this is a system layer, check that a compare property is defined. In alternat
                     key={`maps-${visualData.maps.length}`}
                     maps={visualData.maps}
                     bbox={visualData.bbox}
+                    mapStyle={visualData.mapStyle}
                   />
                 </ExploreCarto>
               )}

--- a/app/assets/scripts/components/stories/single/multi-map.js
+++ b/app/assets/scripts/components/stories/single/multi-map.js
@@ -119,6 +119,7 @@ const MapContainer = styled.section`
   }
 
   > div {
+    box-shadow: 0 0 0 1px ${themeVal('color.baseAlphaC')};
     height: 100%;
   }
 `;

--- a/app/assets/scripts/components/stories/single/multi-map.js
+++ b/app/assets/scripts/components/stories/single/multi-map.js
@@ -1,0 +1,261 @@
+import React, { createRef, useEffect, useRef, useState } from 'react';
+import styled, { css } from 'styled-components';
+import T from 'prop-types';
+import mapboxgl from 'mapbox-gl';
+import syncMove from '@mapbox/mapbox-gl-sync-move';
+
+import config from '../../../config';
+import { glsp } from '../../../styles/utils/theme-values';
+import { themeVal } from '../../../styles/utils/general';
+import media from '../../../styles/utils/media-queries';
+import { visuallyHidden } from '../../../styles/helpers';
+
+// Set mapbox token.
+mapboxgl.accessToken = config.mbToken;
+
+const renderGridColumn = ({ mapCount }) => {
+  if (mapCount < 2) return;
+
+  if (mapCount % 3 !== 0 && mapCount % 2 === 0) {
+    return css`
+      grid-template-columns: repeat(2, 1fr);
+    `;
+  } else {
+    return css`
+      grid-template-columns: repeat(3, 1fr);
+    `;
+  }
+};
+
+const MapsWrapper = styled.div`
+  display: flex;
+  flex-flow: column nowrap;
+  overflow: hidden;
+`;
+
+const MapsNav = styled.ul`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  z-index: 10;
+  display: flex;
+  justify-content: center;
+  padding: ${glsp()};
+
+  li:not(:last-child) {
+    margin-right: ${glsp(0.5)};
+  }
+
+  ${media.largeUp`
+    display: none;
+  `}
+`;
+
+const MapsNavItem = styled.a`
+  &::before {
+    content: '';
+    display: block;
+    width: 1rem;
+    height: 1rem;
+    background: #fff;
+    box-shadow: 0 0 4px 4px ${themeVal('color.baseAlphaA')};
+    border-radius: ${themeVal('shape.ellipsoid')};
+
+    ${({ active }) => active && css`
+      background: ${themeVal('color.primary')};
+    `}
+  }
+
+  span {
+    ${visuallyHidden()}
+  }
+`;
+
+const MapsWrapperInner = styled.div`
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+
+  ${media.largeUp`
+    display: grid;
+    grid-template-columns: 1fr;
+    ${renderGridColumn}
+  `}
+`;
+
+const MapContainer = styled.section`
+  position: relative;
+  min-width: 100vw;
+  height: 100%;
+
+  ${media.largeUp`
+    min-width: auto;
+
+    &:not(:last-child) .mapboxgl-ctrl-logo {
+      display: none;
+    }
+  `}
+
+  h1 {
+    position: absolute;
+    top: ${glsp(0.5)};
+    left: ${glsp(0.5)};
+    z-index: 10;
+    padding: ${glsp(1 / 2, 0.75)};
+    background: #fff;
+    box-shadow: 0 0 4px 4px ${themeVal('color.baseAlphaA')};
+    border-radius: ${themeVal('shape.rounded')};
+    font-size: 0.875rem;
+    font-weight: ${themeVal('type.base.regular')};
+    line-height: 1rem;
+    text-align: center;
+    margin: 0;
+
+    ${media.largeUp`
+      left: 50%;
+      transform: translate(-50%, 0);
+    `}
+  }
+
+  > div {
+    height: 100%;
+  }
+`;
+
+// The small multiple map is setup upon initialization. There's no way to
+// dynamically update it. The mapbox map is set as the passed in ref value.
+const SmallMultipleMap = React.forwardRef((props, ref) => {
+  const { source, id, label, bbox } = props;
+  const mapContainer = useRef(null);
+
+  // Initialize map
+  useEffect(() => {
+    const mbMap = (ref.current = new mapboxgl.Map({
+      attributionControl: false,
+      container: mapContainer.current,
+      style: config.map.styleUrl,
+      logoPosition: 'bottom-right',
+      pitchWithRotate: false,
+      dragRotate: false
+    }));
+
+    if (bbox) {
+      mbMap.fitBounds(bbox);
+    } else {
+      mbMap.jumpTo({ center: [0, 0], zoom: 2 });
+    }
+
+    mbMap.on('load', function () {
+      mbMap.addSource(id, source);
+      mbMap.addLayer(
+        {
+          id: id,
+          type: 'raster',
+          source: id
+        },
+        'admin-0-boundary-bg'
+      );
+    });
+
+    return () => {
+      mbMap.remove();
+    };
+  }, [ref]);
+
+  return (
+    <MapContainer>
+      <h1>{label}</h1>
+      <div ref={mapContainer} />
+    </MapContainer>
+  );
+});
+
+SmallMultipleMap.propTypes = {
+  source: T.object,
+  id: T.string,
+  label: T.string,
+  bbox: T.array
+};
+
+// The MultiMap component displays a series of raster maps in a small multiples
+// fashion. On small screens it displays them side-by-side with a navigation.
+// Because the component needs to keep refs to all the maps to enable syncing
+// this component does not support map updates. If the amount of maps changes,
+// the component must be remounted. Easiest way to achieve this is by using a
+// different key property.
+/* eslint-disable-next-line react/display-name */
+const MultiMap = React.forwardRef((props, ref) => {
+  const { maps, bbox } = props;
+
+  // On small screens the maps are rendered side by side and the container is
+  // programmatically scrolled to the correct place when the navigation is used.
+  // This allows us to keep the same structure for large screens, handle the
+  // syncing and manage display through css.
+  // For this we need a reference to the scrollable DOM node and the clicked
+  // navigation item.
+  const mapsScrollContainer = useRef(null);
+  const [visibleMapMobile, setVisibleMapMobile] = useState(0);
+
+  // Create refs for all the maps.
+  const theRefs = useRef(maps.map((m) => createRef(null)));
+
+  // Set the ref as an object with functions. In this case is a function to
+  // resize the minimaps when the panel is opened/closed.
+  ref.current = {
+    resizeMaps: () => {
+      theRefs.current.forEach((r) => r.current.resize());
+    }
+  };
+
+  // Enable syncing on mount.
+  useEffect(() => {
+    syncMove(theRefs.current.map((r) => r.current));
+  }, []);
+
+  // Scroll to the correct map.
+  useEffect(() => {
+    mapsScrollContainer.current.scrollLeft =
+      window.innerWidth * visibleMapMobile;
+  }, [visibleMapMobile]);
+
+  return (
+    <MapsWrapper>
+      <MapsNav>
+        {maps.map((m, idx) => (
+          <li key={m.id}>
+            <MapsNavItem
+              href='#'
+              active={visibleMapMobile === idx}
+              title={`View map ${idx + 1}`}
+              onClick={(e) => {
+                e.preventDefault();
+                setVisibleMapMobile(idx);
+              }}
+            >
+              <span>View map {idx + 1}</span>
+            </MapsNavItem>
+          </li>
+        ))}
+      </MapsNav>
+      <MapsWrapperInner ref={mapsScrollContainer} mapCount={maps.length}>
+        {maps.map((m, idx) => (
+          <SmallMultipleMap
+            ref={theRefs.current[idx]}
+            key={m.id}
+            bbox={bbox}
+            id={m.id}
+            {...m}
+          />
+        ))}
+      </MapsWrapperInner>
+    </MapsWrapper>
+  );
+});
+
+MultiMap.propTypes = {
+  bbox: T.array,
+  maps: T.array
+};
+
+export default MultiMap;

--- a/app/assets/scripts/components/stories/single/multi-map.js
+++ b/app/assets/scripts/components/stories/single/multi-map.js
@@ -127,7 +127,7 @@ const MapContainer = styled.section`
 // The small multiple map is setup upon initialization. There's no way to
 // dynamically update it. The mapbox map is set as the passed in ref value.
 const SmallMultipleMap = React.forwardRef((props, ref) => {
-  const { source, id, label, bbox } = props;
+  const { source, id, label, bbox, mapStyle } = props;
   const mapContainer = useRef(null);
 
   // Initialize map
@@ -135,7 +135,7 @@ const SmallMultipleMap = React.forwardRef((props, ref) => {
     const mbMap = (ref.current = new mapboxgl.Map({
       attributionControl: false,
       container: mapContainer.current,
-      style: config.map.styleUrl,
+      style: mapStyle || config.map.styleUrl,
       logoPosition: 'bottom-right',
       pitchWithRotate: false,
       dragRotate: false
@@ -155,7 +155,8 @@ const SmallMultipleMap = React.forwardRef((props, ref) => {
           type: 'raster',
           source: id
         },
-        'admin-0-boundary-bg'
+        // Adding the layer under labels is only for the default style.
+        mapStyle ? '' : 'admin-0-boundary-bg'
       );
     });
 
@@ -176,6 +177,7 @@ SmallMultipleMap.propTypes = {
   source: T.object,
   id: T.string,
   label: T.string,
+  mapStyle: T.string,
   bbox: T.array
 };
 
@@ -187,7 +189,7 @@ SmallMultipleMap.propTypes = {
 // different key property.
 /* eslint-disable-next-line react/display-name */
 const MultiMap = React.forwardRef((props, ref) => {
-  const { maps, bbox } = props;
+  const { maps, bbox, mapStyle } = props;
 
   // On small screens the maps are rendered side by side and the container is
   // programmatically scrolled to the correct place when the navigation is used.
@@ -245,6 +247,7 @@ const MultiMap = React.forwardRef((props, ref) => {
             ref={theRefs.current[idx]}
             key={m.id}
             bbox={bbox}
+            mapStyle={mapStyle}
             id={m.id}
             {...m}
           />
@@ -256,6 +259,7 @@ const MultiMap = React.forwardRef((props, ref) => {
 
 MultiMap.propTypes = {
   bbox: T.array,
+  mapStyle: T.string,
   maps: T.array
 };
 

--- a/app/assets/scripts/components/stories/story-air.js
+++ b/app/assets/scripts/components/stories/story-air.js
@@ -188,21 +188,19 @@ export default {
             Because nitrogen dioxide is primarily emitted from burning fossil fuels, changes in its atmospheric concentration can be tied to changes in human activity if the data are properly processed and interpreted. These connections are underscored when comparing different NASA datasets, like observations in changing nightlights during the pandemic. Here we see the illuminated web of highways connecting the Los Angeles metropolitan region. Researchers are using night light observations to track variations in energy use, migration, and transportation in response to social distancing and lockdown measures. These data, collected by the VIIRS instrument aboard the joint NASA-National Oceanic and Atmospheric Administration (NOAA) Suomi-NPP satellite, correlate with changes seen in car traffic on the ground – and, therefore, nitrogen dioxide reductions. While this research is still ongoing, the 31% reduction in NO<sub>2</sub> levels in Los Angeles during the height of pandemic-related lockdowns compared to recent years seems to correspond with a 15% reduction in nighttime lights over highways during the same period.
           </p>
         </>
-      )
-      // visual: {
-      //   type: 'map-layer',
-      //   data: {
-      //     layers: ['nightlights-viirs'],
-      //     date: '2020-03-01T00:00:00Z',
-      //     spotlightId: 'la',
-      //     compare: {
-      //       mapLabel: () => 'February 1, 2020 compared to March 1, 2020',
-      //       layers: ['nightlights-viirs'],
-      //       date: '2020-02-01T00:00:00Z',
-      //       spotlightId: 'la'
-      //     }
-      //   }
-      // }
+      ),
+      visual: {
+        type: 'map-layer',
+        data: {
+          layers: ['nightlights-viirs'],
+          date: '2020-03-01T00:00:00Z',
+          spotlight: 'la',
+          compare: {
+            mapLabel: () => 'February 1, 2020 compared to March 1, 2020',
+            compareDate: () => new Date('2020-02-01T00:00:00Z')
+          }
+        }
+      }
     },
     {
       id: 'measuring-pollution-on-the-ground',

--- a/app/assets/scripts/components/stories/story-air.js
+++ b/app/assets/scripts/components/stories/story-air.js
@@ -1,5 +1,8 @@
 import React from 'react';
 
+import config from '../../config';
+const { api } = config;
+
 export default {
   id: 'air-quality',
   name: 'Air Quality During COVID-19 Shutdowns',
@@ -33,32 +36,67 @@ export default {
           </p>
         </>
       )
+      // Data visual: Los Angeles, USA, February 2020; Landsat Image
     },
     {
       id: 'cities-experiencing-clearer-air',
       name: 'Cities Experiencing Clearer Air During Lockdowns',
       sections: [
         {
-          id: 'part1',
-          name: 'Part 1',
+          id: 'beijing',
+          name: 'Beijing',
           contentComp: (
             <>
               <p>
                 When Chinese authorities suspended travel and closed businesses in late January 2020 in response to the novel coronavirus, Beijing’s nearly 21 million residents saw huge drops in their local nitrogen dioxide levels. In February 2020, concentrations fell by nearly 30% compared to the previous five-year average.
               </p>
             </>
-          )
+          ),
+          visual: {
+            type: 'map-layer',
+            data: {
+              layers: ['no2'],
+              date: '2020-02-01T00:00:00Z',
+              bbox: [115.84, 39.62, 116.85, 40.22],
+              compare: {
+                mapLabel: () => '5 year average compared to February 2020',
+                source: {
+                  type: 'raster',
+                  tiles: [
+                    `${api}/{z}/{x}/{y}@1x?url=s3://covid-eo-data/OMNO2d_HRMBaseline/OMI_trno2_0.10x0.10_Baseline_02_Col3_V4.nc.tif&esampling_method=bilinear&bidx=1&rescale=0%2C1.5e16&color_map=custom_no2`
+                  ]
+                }
+              }
+            }
+          }
         },
         {
-          id: 'part2',
-          name: 'Part 2',
+          id: 'lima',
+          name: 'Lima',
           contentComp: (
             <>
               <p>
                 Cities across South America experienced similar declines in NO<sub>2</sub>. Lima, Peru had some of the most substantial reductions, with nitrogen dioxide levels falling approximately 70% below normal levels.
               </p>
             </>
-          )
+          ),
+          visual: {
+            type: 'map-layer',
+            data: {
+              layers: ['no2'],
+              date: '2020-05-01T00:00:00Z',
+              bbox: [-77.97, -12.75, -76.08, -11.43],
+              compare: {
+                mapLabel: () => '5 year average compared to May 2020',
+                source: {
+                  type: 'raster',
+                  tiles: [
+                    `${api}/{z}/{x}/{y}@1x?url=s3://covid-eo-data/OMNO2d_HRMBaseline/OMI_trno2_0.10x0.10_Baseline_05_Col3_V4.nc.tif&esampling_method=bilinear&bidx=1&rescale=0%2C1.5e16&color_map=custom_no2`
+                  ]
+                }
+              }
+            }
+          }
         }
       ]
     },
@@ -75,7 +113,24 @@ export default {
                 You might think immediate improvements in air quality during shutdowns would be obvious. However, in reality, the way our atmosphere behaves isn’t so clear-cut. Nitrogen dioxide is only one component of air quality: sulfur dioxide, ozone, formaldehyde, and carbon dioxide along with a host of other atmospheric constituents also influence the quality of the air we breathe. The difference in nitrogen dioxide is that it has a relatively short lifetime in the atmosphere. In other words, once it’s emitted, it only lasts a few hours before it disappears. Therefore, once communities entered lockdowns and their mobility was severely restricted, the effect on NO<sub>2</sub> concentrations was the equivalent of flipping a switch. Be that as it may, this isn’t the case with all air pollutants.
               </p>
             </>
-          )
+          ),
+          visual: {
+            type: 'map-layer',
+            data: {
+              layers: ['no2'],
+              date: '2020-04-01T00:00:00Z',
+              bbox: [-37.17, 34.16, 53.78, 68.84],
+              compare: {
+                mapLabel: () => '5 year average compared to April 2020',
+                source: {
+                  type: 'raster',
+                  tiles: [
+                    `${api}/{z}/{x}/{y}@1x?url=s3://covid-eo-data/OMNO2d_HRMBaseline/OMI_trno2_0.10x0.10_Baseline_04_Col3_V4.nc.tif&esampling_method=bilinear&bidx=1&rescale=0%2C1.5e16&color_map=custom_no2`
+                  ]
+                }
+              }
+            }
+          }
         },
         {
           id: 'part2',
@@ -86,7 +141,24 @@ export default {
                 Even with the strong correlation between NO<sub>2</sub> and the combustion of fossil fuels, the relationship between nitrogen dioxide and lockdowns isn’t straightforward either. Atmospheric concentrations of nitrogen dioxide naturally fluctuate throughout the year, and weather patterns also influence its concentrations. For example, nitrogen dioxide typically falls dramatically during spring and summer months, and rain and wind increase its dispersion, lowering local concentrations.Therefore, during the COVID-19 pandemic, scientists are careful to attribute observed changes solely to changes in our behavior and are also looking to determine whether some of the reductions are the result of natural variation.
               </p>
             </>
-          )
+          ),
+          visual: {
+            type: 'map-layer',
+            data: {
+              layers: ['no2'],
+              date: '2020-04-01T00:00:00Z',
+              bbox: [-37.17, 34.16, 53.78, 68.84],
+              compare: {
+                mapLabel: () => '5 year average compared to April 2020',
+                source: {
+                  type: 'raster',
+                  tiles: [
+                    `${api}/{z}/{x}/{y}@1x?url=s3://covid-eo-data/OMNO2d_HRMBaseline/OMI_trno2_0.10x0.10_Baseline_04_Col3_V4.nc.tif&esampling_method=bilinear&bidx=1&rescale=0%2C1.5e16&color_map=custom_no2`
+                  ]
+                }
+              }
+            }
+          }
         }
       ]
     },
@@ -117,6 +189,20 @@ export default {
           </p>
         </>
       )
+      // visual: {
+      //   type: 'map-layer',
+      //   data: {
+      //     layers: ['nightlights-viirs'],
+      //     date: '2020-03-01T00:00:00Z',
+      //     spotlightId: 'la',
+      //     compare: {
+      //       mapLabel: () => 'February 1, 2020 compared to March 1, 2020',
+      //       layers: ['nightlights-viirs'],
+      //       date: '2020-02-01T00:00:00Z',
+      //       spotlightId: 'la'
+      //     }
+      //   }
+      // }
     },
     {
       id: 'measuring-pollution-on-the-ground',
@@ -132,6 +218,7 @@ export default {
               </p>
             </>
           )
+          // Data visual: Planet Labs grounded plane imagery at BWI/ATL airport
         },
         {
           id: 'part2',
@@ -143,6 +230,7 @@ export default {
               </p>
             </>
           )
+          // Data visual: Pandora NO2/formaldehyde levels at BWI/ATL airport
         }
       ]
     },
@@ -155,7 +243,19 @@ export default {
             After the initial shock of COVID-related shutdowns in the spring, communities worldwide have begun to reopen and gradually increase mobility. Cars have returned to the road, and travel restrictions have been slowly easing. These resumptions in behavior have subsequently corresponded with relative increases in nitrogen dioxide levels and other air pollutants, as air quality levels begin to return to pre-pandemic levels. Therefore, any long-term gains in overall air quality from the temporary reductions during short-term lockdowns appears to be minimal with regard to nitrogen dioxide. Looking to the future, NASA scientists will continue to monitor nitrogen dioxide levels and long-term trends around the world and at home. NASA is expected to launch its Tropospheric Emissions: Monitoring of Pollution, (TEMPO) instrument in 2022, which will provide hourly, high-resolution measurements of nitrogen dioxide, ozone, and other air pollutants across North America, revolutionizing future air quality forecasts.
           </p>
         </>
-      )
+      ),
+      visual: {
+        type: 'map-layer',
+        data: {
+          layers: ['no2'],
+          bbox: [115.84, 39.62, 116.85, 40.22],
+          compare: {
+            mapLabel: () => 'February 2020 compared current NO₂ levels',
+            layers: ['no2'],
+            date: '2020-02-01T00:00:00Z'
+          }
+        }
+      }
     }
   ]
 };

--- a/app/index.html
+++ b/app/index.html
@@ -25,11 +25,11 @@
     <meta property='og:description' content='{{appDescription}}' />
 
     <!-- build:css /assets/styles/vendor.css -->
-    <link rel='stylesheet' href='../node_modules/mapbox-gl/dist/mapbox-gl.css' />
-    <link rel='stylesheet' href='../node_modules/@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.css' />
-    <link rel='stylesheet' href='../node_modules/mapbox-gl-compare/dist/mapbox-gl-compare.css' />
-    <link rel="stylesheet" href="../node_modules/@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css" />
-    <link rel='stylesheet' href='../node_modules/react-datepicker/dist/react-datepicker.css' />
+    <link rel='stylesheet' href='/node_modules/mapbox-gl/dist/mapbox-gl.css' />
+    <link rel='stylesheet' href='/node_modules/@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.css' />
+    <link rel='stylesheet' href='/node_modules/mapbox-gl-compare/dist/mapbox-gl-compare.css' />
+    <link rel='stylesheet' href="/node_modules/@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css" />
+    <link rel='stylesheet' href='/node_modules/react-datepicker/dist/react-datepicker.css' />
     <!-- endbuild -->
 
     <link rel='author' type='text/plain' href='humans.txt' />

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "@d3fc/d3fc-axis": "^3.0.0",
     "@mapbox/mapbox-gl-draw": "^1.1.2",
     "@mapbox/mapbox-gl-geocoder": "^4.5.1",
+    "@mapbox/mapbox-gl-sync-move": "^0.3.0",
     "@turf/area": "^6.0.1",
     "@turf/bbox": "^6.0.1",
     "clipboard": "^2.0.6",


### PR DESCRIPTION
This PR implements the ability to enable comparison for layer stories.

> :warning::warning: Adding comparison to stories was not straightforward and several pieces of code were touched. Al the other map related pages should be tested to ensure that everything still works. :warning::warning:

Adding the compare functionality to a story layer is done through the `compare` property inside `visual`.
This can be done in a couple of different ways depending of some factors:

### Enabling the existing compare on an existing layer

If a given layer already has the compare defined (because is used on other pages) it is possible to simply enable it and maintain all settings.
```
  visual: {
    type: 'map-layer',
    data: {
      layers: ['no2'],
      date: '2020-03-01T00:00:00Z',
      compare: true
    }
  }
```

### Extending the existing compare on an existing layer

If the existent compare properties do not suit the story's visuals, they can be overridden. The layer's base compare is used and properties provided through the story are used as overrides.
```
visual: {
  type: 'map-layer',
  data: {
    layers: ['no2'],
    date: '2020-03-01T00:00:00Z',
    compare: {
      mapLabel: date => '2020-01-01 vs 2020-03-01',
      compareDate: date => new Date('2020-01-01T00:00:00Z')
    }
  }
}
```

In the above example we're changing the compare date to a fixed one (no2 default is 2y from the selected date). We're also changing the map compare label.

### Adding a compare to a layer

If the layer being displayed doesn't have a compare defined in the app it is possible to add one, using the `compare` to provide all the properties.
```
visual: {
  type: 'map-layer',
  data: {
    spotlight: null,
    date: null,
    bbox: [-30, 30, 30, -30],
    layers: [
      {
        id: 'population-neo',
        name: 'Population',
        type: 'raster-timeseries',
        source: {
          type: 'raster',
          tiles: [
            'url'
          ]
        }
      }
    ],
    compare: {
      mapLabel: date => 'Foo vs Bar',
      compareDate: date => new Date('2020-01-01T00:00:00Z')
      source: {
        type: 'raster-timeseries',
        tiles: [
          'url compare'
        ]
      }
    }
  }
}
```

Functions:
 - `mapLabel(date: Date)` - Must return a string to displayed.
 - `compareDate(date: Date)` - Must return a date object to use as comparison.
