### PR TITLE
First draft of MODIS wildfire visual

### DIFF
--- a/app/assets/scripts/components/stories/single/multi-map.js
+++ b/app/assets/scripts/components/stories/single/multi-map.js
@@ -155,8 +155,8 @@ const SmallMultipleMap = React.forwardRef((props, ref) => {
           type: 'raster',
           source: id
         },
-        // Adding the layer under labels is only for the default style.
-        mapStyle ? '' : 'admin-0-boundary-bg'
+        // Assumption is that any style used has 'admin-0-boundary-bg' layer.
+        'admin-0-boundary-bg'
       );
     });
 

--- a/app/assets/scripts/components/stories/story-lcluc.js
+++ b/app/assets/scripts/components/stories/story-lcluc.js
@@ -1,5 +1,8 @@
 import React from 'react';
 
+import config from '../../config';
+const { api } = config;
+
 export default {
   id: 'changing-lanscapes',
   name: 'Changing landscapes during the COVID-19 pandemic',
@@ -80,7 +83,75 @@ export default {
             Social distancing measures during the pandemic also affected how humans interact with the natural environment. For example, satellites observed a reduction in managed forest fires, otherwise known as prescribed burns, on federal lands during the pandemic. Prescribed fires are an important way to reduce fuel loads and maintain biodiversity. In March 2020, the U.S. Forest Service and other federal agencies temporarily suspended all prescribed burns on federal lands in the Southeast United States. State agencies in Mississippi, South Carolina, and North Carolina also issued spring burning bans in response to the COVID-19 pandemic. The Forest Service’s suspension aimed to prevent virus exposure to employees and to reduce smoke exposure to vulnerable communities, since COVID-19 is a respiratory illness. Researchers at NASA’s Goddard Space Flight Center detected a 42% reduction in active fires this spring compared to previous years.
           </p>
         </>
-      )
+      ),
+      visual: {
+        type: 'multi-map',
+        data: {
+          bbox: [-75, 24, -107, 40],
+          maps: [
+            {
+              id: 'mar',
+              label: 'March 2020',
+              source: {
+                type: 'raster',
+                tiles: [
+                  `${api}/{z}/{x}/{y}@1x?url=s3://covid-eo-data/standalone/fire-anomalies/MODIS-AF_anomalies_USA_Y2020_M3_0.25.tif&resampling_method=bilinear&rescale=-10%2C10&bidx=1&color_map=bwr`
+                ]
+              }
+            },
+            {
+              id: 'apr',
+              label: 'April 2020',
+              source: {
+                type: 'raster',
+                tiles: [
+                  `${api}/{z}/{x}/{y}@1x?url=s3://covid-eo-data/standalone/fire-anomalies/MODIS-AF_anomalies_USA_Y2020_M4_0.25.tif&resampling_method=bilinear&rescale=-10%2C10&bidx=1&color_map=bwr`
+                ]
+              }
+            },
+            {
+              id: 'may',
+              label: 'May 2020',
+              source: {
+                type: 'raster',
+                tiles: [
+                  `${api}/{z}/{x}/{y}@1x?url=s3://covid-eo-data/standalone/fire-anomalies/MODIS-AF_anomalies_USA_Y2020_M5_0.25.tif&resampling_method=bilinear&rescale=-10%2C10&bidx=1&color_map=bwr`
+                ]
+              }
+            },
+            {
+              id: 'jun', // The id is mandatory and must be unique in all maps.
+              label: 'June 2020',
+              source: {
+                type: 'raster',
+                tiles: [
+                  `${api}/{z}/{x}/{y}@1x?url=s3://covid-eo-data/standalone/fire-anomalies/MODIS-AF_anomalies_USA_Y2020_M6_0.25.tif&resampling_method=bilinear&rescale=-10%2C10&bidx=1&color_map=bwr`
+                ]
+              }
+            },
+            {
+              id: 'jul', // The id is mandatory and must be unique in all maps.
+              label: 'July 2020',
+              source: {
+                type: 'raster',
+                tiles: [
+                  `${api}/{z}/{x}/{y}@1x?url=s3://covid-eo-data/standalone/fire-anomalies/MODIS-AF_anomalies_USA_Y2020_M7_0.25.tif&resampling_method=bilinear&rescale=-10%2C10&bidx=1&color_map=bwr`
+                ]
+              }
+            },
+            {
+              id: 'jun', // The id is mandatory and must be unique in all maps.
+              label: 'August 2020',
+              source: {
+                type: 'raster',
+                tiles: [
+                  `${api}/{z}/{x}/{y}@1x?url=s3://covid-eo-data/standalone/fire-anomalies/MODIS-AF_anomalies_USA_Y2020_M8_0.25.tif&resampling_method=bilinear&rescale=-10%2C10&bidx=1&color_map=bwr`
+                ]
+              }
+            }
+          ]
+        }
+      }
     },
     {
       id: 'what-we-learned',

--- a/app/assets/scripts/components/stories/story-lcluc.js
+++ b/app/assets/scripts/components/stories/story-lcluc.js
@@ -88,64 +88,65 @@ export default {
         type: 'multi-map',
         data: {
           bbox: [-75, 24, -107, 40],
+          mapStyle: 'mapbox://styles/covid-nasa/ckhyrwyqa10fn19pu38wdrpjo',
           maps: [
             {
-              id: 'mar',
+              id: 'fire-mar',
               label: 'March 2020',
               source: {
                 type: 'raster',
                 tiles: [
-                  `${api}/{z}/{x}/{y}@1x?url=s3://covid-eo-data/standalone/fire-anomalies/MODIS-AF_anomalies_USA_Y2020_M3_0.25.tif&resampling_method=bilinear&rescale=-10%2C10&bidx=1&color_map=bwr`
+                  `${api}/{z}/{x}/{y}@1x?url=s3://covid-eo-data/standalone/fire-anomalies/MODIS-AF_anomalies_USA_Y2020_M3_0.25-dashboard.tif&resampling_method=bilinear&rescale=-10,10&color_map=bwr`
                 ]
               }
             },
             {
-              id: 'apr',
+              id: 'fire-apr',
               label: 'April 2020',
               source: {
                 type: 'raster',
                 tiles: [
-                  `${api}/{z}/{x}/{y}@1x?url=s3://covid-eo-data/standalone/fire-anomalies/MODIS-AF_anomalies_USA_Y2020_M4_0.25.tif&resampling_method=bilinear&rescale=-10%2C10&bidx=1&color_map=bwr`
+                  `${api}/{z}/{x}/{y}@1x?url=s3://covid-eo-data/standalone/fire-anomalies/MODIS-AF_anomalies_USA_Y2020_M4_0.25-dashboard.tif&resampling_method=bilinear&rescale=-10,10&color_map=bwr`
                 ]
               }
             },
             {
-              id: 'may',
+              id: 'fire-may',
               label: 'May 2020',
               source: {
                 type: 'raster',
                 tiles: [
-                  `${api}/{z}/{x}/{y}@1x?url=s3://covid-eo-data/standalone/fire-anomalies/MODIS-AF_anomalies_USA_Y2020_M5_0.25.tif&resampling_method=bilinear&rescale=-10%2C10&bidx=1&color_map=bwr`
+                  `${api}/{z}/{x}/{y}@1x?url=s3://covid-eo-data/standalone/fire-anomalies/MODIS-AF_anomalies_USA_Y2020_M5_0.25-dashboard.tif&resampling_method=bilinear&rescale=-10,10&color_map=bwr`
                 ]
               }
             },
             {
-              id: 'jun', // The id is mandatory and must be unique in all maps.
+              id: 'fire-jun',
               label: 'June 2020',
               source: {
                 type: 'raster',
                 tiles: [
-                  `${api}/{z}/{x}/{y}@1x?url=s3://covid-eo-data/standalone/fire-anomalies/MODIS-AF_anomalies_USA_Y2020_M6_0.25.tif&resampling_method=bilinear&rescale=-10%2C10&bidx=1&color_map=bwr`
+                  `${api}/{z}/{x}/{y}@1x?url=s3://covid-eo-data/standalone/fire-anomalies/MODIS-AF_anomalies_USA_Y2020_M6_0.25-dashboard.tif&resampling_method=bilinear&rescale=-10,10&color_map=bwr`
                 ]
               }
             },
             {
-              id: 'jul', // The id is mandatory and must be unique in all maps.
+              id: 'fire-jul',
               label: 'July 2020',
               source: {
                 type: 'raster',
                 tiles: [
-                  `${api}/{z}/{x}/{y}@1x?url=s3://covid-eo-data/standalone/fire-anomalies/MODIS-AF_anomalies_USA_Y2020_M7_0.25.tif&resampling_method=bilinear&rescale=-10%2C10&bidx=1&color_map=bwr`
+                  `${api}/{z}/{x}/{y}@1x?url=s3://covid-eo-data/standalone/fire-anomalies/MODIS-AF_anomalies_USA_Y2020_M7_0.25-dashboard.tif&resampling_method=bilinear&rescale=-10,10&color_map=bwr`
                 ]
               }
             },
             {
-              id: 'jun', // The id is mandatory and must be unique in all maps.
+              id: 'fire-aug',
               label: 'August 2020',
               source: {
                 type: 'raster',
                 tiles: [
-                  `${api}/{z}/{x}/{y}@1x?url=s3://covid-eo-data/standalone/fire-anomalies/MODIS-AF_anomalies_USA_Y2020_M8_0.25.tif&resampling_method=bilinear&rescale=-10%2C10&bidx=1&color_map=bwr`
+                  `${api}/{z}/{x}/{y}@1x?url=s3://covid-eo-data/standalone/fire-anomalies/MODIS-AF_anomalies_USA_Y2020_M8_0.25-dashboard.tif&resampling_method=bilinear&rescale=-10,10&color_map=bwr`
                 ]
               }
             }


### PR DESCRIPTION
Contribute to #464 

This PR adds the wildfire anomaly data as a multi-map to the dashboard.

![image](https://user-images.githubusercontent.com/751330/100232891-e4433200-2f20-11eb-9140-f22a61c53f70.png)

Open questions, to address with the science team:

* that `multi-map` is the way to go
* whether to reprocess the data and mark `0` as nodata. This would make the white areas transparent.
* if we decide to treat '0' as nodata, we should use a different base layer. The satellite layer will generate some noise, and make it harder to clearly see the blues and reds.
