### PR TITLE
Legends

### DIFF
--- a/app/assets/scripts/components/stories/single/index.js
+++ b/app/assets/scripts/components/stories/single/index.js
@@ -505,12 +505,14 @@ If this is a system layer, check that a compare property is defined. In alternat
     // If there are no visuals there's nothing to do.
     if (!visual) return;
 
+    let layersWithLegend = null;
+
     if (visual.type === 'map-layer') {
       const { layers = [], spotlight } = visual.data;
 
       const mapLayers = getMapLayers(spotlight, layers);
       // Map the layer ids to layer definition objects.
-      const layersWithLegend = layers
+      layersWithLegend = layers
         .map((l, idx) => {
           if (typeof l === 'string') {
             const layerDef = mapLayers.find((layer) => layer.id === l);
@@ -524,40 +526,45 @@ If this is a system layer, check that a compare property is defined. In alternat
           return l;
         })
         .filter((l) => !!l.legend);
-
-      if (!layersWithLegend.length) return null;
-
-      return (
-        <MapLayerLegend>
-          <Heading as='h2' size='medium'>
-            About the data
-          </Heading>
-          {layersWithLegend.map((l) => {
-            const { type } = l.legend;
-            const legend = {
-              ...l.legend,
-              // We don't have adjustable gradients here, so convert to normal one.
-              type: type === 'gradient-adjustable' ? 'gradient' : type
-            };
-            return (
-              <div key={l.id}>
-                <Heading as='h3' size='small'>
-                  {replaceSub2(l.name)}
-                </Heading>
-                <LayerLegend
-                  dataOrder={l.dataOrder}
-                  legend={legend}
-                  id={l.id}
-                />
-                <LayerInfo>
-                  <p>{l.info}</p>
-                </LayerInfo>
-              </div>
-            );
-          })}
-        </MapLayerLegend>
-      );
     }
+
+    if (visual.type === 'multi-map') {
+      const { legend, name } = visual.data;
+      layersWithLegend = [{
+        id: item.id,
+        legend,
+        name: name || 'Multi map'
+      }];
+    }
+
+    if (!layersWithLegend) return null;
+
+    return (
+      <MapLayerLegend>
+        <Heading as='h2' size='medium'>
+          About the data
+        </Heading>
+        {layersWithLegend.map((l) => {
+          const { type } = l.legend;
+          const legend = {
+            ...l.legend,
+            // We don't have adjustable gradients here, so convert to normal one.
+            type: type === 'gradient-adjustable' ? 'gradient' : type
+          };
+          return (
+            <div key={l.id}>
+              <Heading as='h3' size='small'>
+                {replaceSub2(l.name)}
+              </Heading>
+              <LayerLegend dataOrder={l.dataOrder} legend={legend} id={l.id} />
+              <LayerInfo>
+                <p>{l.info}</p>
+              </LayerInfo>
+            </div>
+          );
+        })}
+      </MapLayerLegend>
+    );
   }
 
   renderChapterDropdown (itemName) {

--- a/app/assets/scripts/components/stories/single/index.js
+++ b/app/assets/scripts/components/stories/single/index.js
@@ -505,7 +505,7 @@ If this is a system layer, check that a compare property is defined. In alternat
     // If there are no visuals there's nothing to do.
     if (!visual) return;
 
-    let layersWithLegend = null;
+    let layersWithLegend = [];
 
     if (visual.type === 'map-layer') {
       const { layers = [], spotlight } = visual.data;
@@ -528,7 +528,7 @@ If this is a system layer, check that a compare property is defined. In alternat
         .filter((l) => !!l.legend);
     }
 
-    if (visual.type === 'multi-map') {
+    if (visual.type === 'multi-map' && visual.data.legend) {
       const { legend, name } = visual.data;
       layersWithLegend = [{
         id: item.id,
@@ -537,7 +537,7 @@ If this is a system layer, check that a compare property is defined. In alternat
       }];
     }
 
-    if (!layersWithLegend) return null;
+    if (!layersWithLegend.length) return null;
 
     return (
       <MapLayerLegend>


### PR DESCRIPTION
Legends are now supported for multimap visuals. One legend can be specified for the whole set of maps.
Add like so:
```diff
visual: {
  type: 'multi-map',
+  data: {
+    name: 'Legend name', // When not provided 'Multi map' is used. This custom legend name is only needed for multi-maps legends, since for others the layer name is used.
+    legend: {
+      type: 'gradient',
+      min: 'less',
+      max: 'more',
+      stops: [
+        '#ff0000',
+        '#0000ff'
+      ]
+    },
    maps: [
      // map definition
    ]
  }
}
```

For the custom layers like in `understanding-impacts-venetian-lagoon` you just need to add the legend to the layer, but make sure the layer has a `name`
```diff
 visual: {
   type: 'map-layer',
   data: {
     bbox: [12.0327, 44.7896, 13.8208, 45.7885],
     layers: [
       {
         id: 'tsm-nas',
         type: 'raster',
         source: {
           // source definition
         },
+        name: 'The layer name',
+        legend: {
+          type: 'gradient',
+          min: 'less',
+          max: 'more',
+          stops: [
+            '#99c5e0',
+            '#050308'
+          ]
+        }
       }
     ]
   }
 }
```