### PR TITLE
Atlanta NO2 visuals

### DIFF
--- a/app/assets/scripts/components/stories/story-air.js
+++ b/app/assets/scripts/components/stories/story-air.js
@@ -255,23 +255,21 @@ export default {
             type: 'multi-map',
             data: {
               bbox: [-84.5549, 33.5242, -84.2198, 33.9889],
-              data: {
-                name: 'NO₂ levels',
-                legend: {
-                  type: 'gradient',
-                  min: '1',
-                  max: '3.5',
-                  stops: [
-                    '#99c5e0',
-                    '#f9eaa9',
-                    '#f7765d',
-                    '#c13b72',
-                    '#461070',
-                    '#050308'
-                  ]
-                },
-                info: 'Darker colors indicate higher nitrogen dioxide (NO₂) levels associated and more activity. Lighter colors indicate lower levels of NO₂ and less activity.'
+              name: 'NO₂ levels',
+              legend: {
+                type: 'gradient',
+                min: '1',
+                max: '3.5',
+                stops: [
+                  '#99c5e0',
+                  '#f9eaa9',
+                  '#f7765d',
+                  '#c13b72',
+                  '#461070',
+                  '#050308'
+                ]
               },
+              info: 'Darker colors indicate higher nitrogen dioxide (NO₂) levels associated and more activity. Lighter colors indicate lower levels of NO₂ and less activity.',
               maps: [
                 {
                   id: 'no2-mar-2019',

--- a/app/assets/scripts/components/stories/story-air.js
+++ b/app/assets/scripts/components/stories/story-air.js
@@ -270,6 +270,7 @@ export default {
                 ]
               },
               info: 'Darker colors indicate higher nitrogen dioxide (NO₂) levels associated and more activity. Lighter colors indicate lower levels of NO₂ and less activity.',
+              mapsPerRow: 5,
               maps: [
                 {
                   id: 'no2-mar-2019',


### PR DESCRIPTION
First implementation of #494 

Depends on: #493 

Currently looks like: 

![image](https://user-images.githubusercontent.com/751330/100891143-e2ddb080-34b0-11eb-9392-48c8766352f9.png)

Next step: figure out the best way to get the visuals side-by-side. cc @danielfdsilva 