### PR TITLE
LCLUC visuals - raster layer bug fix + legend

### DIFF
--- a/app/assets/scripts/components/common/layers/types.js
+++ b/app/assets/scripts/components/common/layers/types.js
@@ -176,9 +176,19 @@ export const layerTypes = {
   },
   raster: {
     update: (ctx, layerInfo, prevProps) => {
-      const { mbMapComparing, mbMapComparingLoaded, props } = ctx;
-      const { id, compare, paint } = layerInfo;
+      const { mbMap, mbMapComparing, mbMapComparingLoaded, props } = ctx;
+      const { id, compare, paint, source } = layerInfo;
       const { comparing } = props;
+
+      // Check if the source tiles have changed and need to be replaced. This
+      // may happen in the stories when maintaining the layer and changing the
+      // spotlight. One example is the slowdown raster layer on la and sf.
+      const sourceTiles = mbMap.getSource(id).tiles;
+      const newSourceTiles = source.tiles;
+      // Quick compare
+      if (sourceTiles && sourceTiles.join('-') !== newSourceTiles.join('-')) {
+        replaceRasterTiles(mbMap, id, newSourceTiles);
+      }
 
       // Do not update if:
       if (

--- a/app/assets/scripts/components/stories/single/about-data.js
+++ b/app/assets/scripts/components/stories/single/about-data.js
@@ -37,7 +37,7 @@ export const LayerInfo = styled.div`
 
 const AboutData = ({ visual, id }) => {
   // If there are no visuals there's nothing to do.
-  if (!visual) return;
+  if (!visual) return null;
 
   let layersWithLegend = [];
 

--- a/app/assets/scripts/components/stories/single/about-data.js
+++ b/app/assets/scripts/components/stories/single/about-data.js
@@ -1,0 +1,122 @@
+import React from 'react';
+import styled from 'styled-components';
+import T from 'prop-types';
+
+import LayerLegend from '../../common/layer-legend';
+import Heading from '../../../styles/type/heading';
+import collecticon from '../../../styles/collecticons';
+
+import { glsp } from '../../../styles/utils/theme-values';
+import {
+  getMapLayers
+} from './utils';
+import { replaceSub2 } from '../../../utils/format';
+
+const MapLayerLegend = styled.div`
+  display: grid;
+  grid-gap: ${glsp(0.5)};
+`;
+
+export const LayerInfo = styled.div`
+  display: grid;
+  grid-template-columns: min-content 1fr;
+  grid-gap: ${glsp(0.5)};
+  font-size: 0.875rem;
+  padding-top: ${glsp(0.5)};
+
+  &::before {
+    ${collecticon('circle-information')}
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  p {
+    grid-row: 1;
+  }
+`;
+
+const AboutData = ({ visual, id }) => {
+  // If there are no visuals there's nothing to do.
+  if (!visual) return;
+
+  let layersWithLegend = [];
+
+  if (visual.type === 'map-layer') {
+    const { layers = [], spotlight } = visual.data;
+
+    const mapLayers = getMapLayers(spotlight, layers);
+    // Map the layer ids to layer definition objects.
+    layersWithLegend = layers
+      .map((l, idx) => {
+        if (typeof l === 'string') {
+          const layerDef = mapLayers.find((layer) => layer.id === l);
+          if (!layerDef) {
+            throw new Error(
+              `Layer definition not found for story layer with id [${l}]`
+            );
+          }
+          return layerDef;
+        }
+        return l;
+      })
+      .filter((l) => !!l.legend);
+  }
+
+  if (visual.type === 'multi-map' && visual.data.legend) {
+    const { legend, name, info } = visual.data;
+    layersWithLegend = [{
+      id: id,
+      legend,
+      info,
+      name: name || 'Multi map'
+    }];
+  }
+
+  if (!layersWithLegend.length && !visual.about) return null;
+
+  return (
+    <MapLayerLegend>
+      <Heading as='h2' size='medium'>
+        About the data
+      </Heading>
+      {layersWithLegend.map((l) => {
+        const { type } = l.legend;
+        const legend = {
+          ...l.legend,
+          // We don't have adjustable gradients here, so convert to normal one.
+          type: type === 'gradient-adjustable' ? 'gradient' : type
+        };
+        return (
+          <div key={l.id}>
+            <Heading as='h3' size='small'>
+              {replaceSub2(l.name)}
+            </Heading>
+            <LayerLegend dataOrder={l.dataOrder} legend={legend} id={l.id} />
+            <LayerInfo>
+              <p>{l.info}</p>
+            </LayerInfo>
+          </div>
+        );
+      })}
+      {visual.about}
+    </MapLayerLegend>
+  );
+};
+
+AboutData.propTypes = {
+  id: T.string,
+  visual: T.shape({
+    type: T.string,
+    about: T.node,
+    data: T.shape({
+      spotlight: T.string,
+      layers: T.array,
+      legend: T.object,
+      item: T.object,
+      name: T.string,
+      info: T.node
+    })
+  })
+};
+
+export default AboutData;

--- a/app/assets/scripts/components/stories/single/utils.js
+++ b/app/assets/scripts/components/stories/single/utils.js
@@ -1,0 +1,128 @@
+import React from 'react';
+import get from 'lodash.get';
+import find from 'lodash.find';
+
+import { getSpotlightLayers } from '../../common/layers';
+
+export const findById = (haystack = [], id) => {
+  const idx = haystack.findIndex((c) => c.id === id);
+  return [idx === -1 ? null : idx, haystack[idx]];
+};
+
+export const getPreviousItem = (chapters, currChapterIdx, currSectionIdx = 0) => {
+  // Try to get the previous section.
+  const chapter = chapters[currChapterIdx];
+  const prevSec = get(chapter, ['sections', currSectionIdx - 1]);
+  if (prevSec) {
+    return {
+      chapter,
+      section: prevSec
+    };
+  }
+
+  // There's no previous section. Get the previous chapter.
+  const prevChapter = chapters[currChapterIdx - 1];
+  // There's no previous chapter.
+  if (!prevChapter) return null;
+
+  // If the chapter has sections return the last
+  if (prevChapter.sections) {
+    const lastSection = prevChapter.sections[prevChapter.sections.length - 1];
+    return {
+      chapter: prevChapter,
+      section: lastSection
+    };
+  } else {
+    return {
+      chapter: prevChapter
+    };
+  }
+};
+
+export const getNextItem = (chapters, currChapterIdx, currSectionIdx = 0) => {
+  // Try to get the next section.
+  const chapter = chapters[currChapterIdx];
+  const nextSec = get(chapter, ['sections', currSectionIdx + 1]);
+  if (nextSec) {
+    return {
+      chapter,
+      section: nextSec
+    };
+  }
+
+  // There's no next section. Get the next chapter.
+  const nextChapter = chapters[currChapterIdx + 1];
+  // There's no next chapter.
+  if (!nextChapter) return null;
+
+  // If the chapter has sections return the first
+  if (nextChapter.sections) {
+    return {
+      chapter: nextChapter,
+      section: nextChapter.sections[0]
+    };
+  } else {
+    return {
+      chapter: nextChapter
+    };
+  }
+};
+
+export const createItemUrl = (story, item) => {
+  if (!item) return '/discoveries';
+
+  const { chapter, section } = item;
+  const base = `/discoveries/${story.id}/${chapter.id}`;
+  return section ? `${base}/${section.id}` : base;
+};
+
+export const getCurrentItemNum = (chapterIdx, sectionIdx = null) => {
+  const sec = sectionIdx !== null ? `.${sectionIdx + 1}` : '';
+  return `${chapterIdx + 1}${sec}`;
+};
+
+export const getCurrentItemName = (chapter, section = null) => {
+  return section ? (
+    <>
+      {chapter.name} ({section.name})
+    </>
+  ) : (
+    <>{chapter.name}</>
+  );
+};
+
+export const getMapLayers = (spotlightId, layers) => {
+  return [
+    ...getSpotlightLayers(spotlightId || 'global'),
+    // Include any layer that was defined on the story. These will be custom
+    // layers specific for this chapter. Mostly external TMS
+    ...layers.reduce(
+      (acc, l) => (typeof l === 'string' ? acc : [...acc, l]),
+      []
+    )
+  ];
+};
+
+export const getMapMessage = (layers, item, date) => {
+  const renderMsg = (mapLabel) =>
+    mapLabel
+      ? typeof mapLabel === 'function'
+        ? mapLabel(date)
+        : mapLabel
+      : '';
+
+  // The map label can come directly from a layer's visual which is the case
+  // when there's only one map. Or it can also come from the compare map, when a
+  // map is being compared. The item0s mapLabel will take precedence.
+  const itemMapLabel = get(item, 'visual.data.mapLabel');
+  if (itemMapLabel) {
+    return [true, renderMsg(itemMapLabel)];
+  }
+
+  // Check if there's any layer that's comparing.
+  const comparingLayer = find(layers, 'comparing');
+  const isComparing = !!comparingLayer;
+  const compareMapLabel = get(comparingLayer, 'compare.mapLabel');
+
+  return [isComparing, renderMsg(compareMapLabel)];
+};

--- a/app/assets/scripts/components/stories/story-lcluc.js
+++ b/app/assets/scripts/components/stories/story-lcluc.js
@@ -1,17 +1,9 @@
 import React from 'react';
-import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 
-import Heading from '../../styles/type/heading';
-import { glsp } from '../../styles/utils/theme-values';
-
 import config from '../../config';
+import { LayerInfo } from './single/about-data';
 const { api } = config;
-
-const MapLayerLegend = styled.div`
-  display: grid;
-  grid-gap: ${glsp(0.5)};
-`;
 
 export default {
   id: 'changing-landscapes',
@@ -23,22 +15,17 @@ export default {
       id: 'changing-behavior',
       name: 'Changing Behavior and Changing Landscapes',
       contentComp: (
-        <>
-          <p>
-            Throughout the COVID-19 pandemic, governments have implemented, eased, and re-implemented restrictions limiting mobility and international travel to help slow the spread of the virus. As a result, people have largely stayed home, and the ways in which we interact with the human-made and natural environments have changed. These changes have reverberated throughout Earth’s systems and are observed in different ways by NASA satellites.
-          </p>
-          <MapLayerLegend>
-            <Heading as='h2' size='medium'>
-              About the data
-            </Heading>
-            <p>
-              Landsat-8 imagery, visualized with the RGB bands.
-            </p>
-          </MapLayerLegend>
-        </>
+        <p>
+          Throughout the COVID-19 pandemic, governments have implemented, eased, and re-implemented restrictions limiting mobility and international travel to help slow the spread of the virus. As a result, people have largely stayed home, and the ways in which we interact with the human-made and natural environments have changed. These changes have reverberated throughout Earth’s systems and are observed in different ways by NASA satellites.
+        </p>
       ),
       visual: {
         type: 'map-layer',
+        about: (
+          <LayerInfo>
+            <p>Landsat-8 imagery, visualized with the RGB bands.</p>
+          </LayerInfo>
+        ),
         data: {
           bbox: [113.7442, 30.2021, 114.859, 30.9092],
           mapLabel: () => 'Feb 25, 2020',
@@ -72,22 +59,17 @@ export default {
       id: 'changes-in-traffic',
       name: 'Changes in Traffic and Parking Lot Patterns',
       contentComp: (
-        <>
-          <p>
-            At different stages of the pandemic, nonessential businesses like shopping malls closed temporarily, while essential businesses like grocery stores were allowed to remain open. The effect of nonessential business closures on surface transportation around the world was so significant that it could be seen from space. For example, the imagery shown here provides a stark picture of empty parking lots near deserted commercial districts in and around Los Angeles. Blue areas represent places where slowdowns were most severe. Scientists obtained these data by combining remote sensing technology known as synthetic aperture radar, or SAR, with high-resolution imagery from Planet Labs. By comparing SAR images of the same areas before and after pandemic-related lockdowns, decreases in car activity in Los Angeles near airports, sports stadiums, and shopping malls were visible from space.
-          </p>
-          <MapLayerLegend>
-            <Heading as='h2' size='medium'>
-              About the data
-            </Heading>
-            <p>
-              Slowdown Proxy Maps show areas with the greatest reduction in car activity shaded in blue. Darker blues indicate areas of greater change.
-            </p>
-          </MapLayerLegend>
-        </>
+        <p>
+          At different stages of the pandemic, nonessential businesses like shopping malls closed temporarily, while essential businesses like grocery stores were allowed to remain open. The effect of nonessential business closures on surface transportation around the world was so significant that it could be seen from space. For example, the imagery shown here provides a stark picture of empty parking lots near deserted commercial districts in and around Los Angeles. Blue areas represent places where slowdowns were most severe. Scientists obtained these data by combining remote sensing technology known as synthetic aperture radar, or SAR, with high-resolution imagery from Planet Labs. By comparing SAR images of the same areas before and after pandemic-related lockdowns, decreases in car activity in Los Angeles near airports, sports stadiums, and shopping malls were visible from space.
+        </p>
       ),
       visual: {
         type: 'map-layer',
+        about: (
+          <LayerInfo>
+            <p>Slowdown Proxy Maps show areas with the greatest reduction in car activity shaded in blue. Darker blues indicate areas of greater change.</p>
+          </LayerInfo>
+        ),
         data: {
           bbox: [-118.2645, 34.0486, -118.2059, 34.0930],
           spotlight: 'la',
@@ -99,22 +81,17 @@ export default {
       id: 'changes-in-ports',
       name: 'Tracking Changes in Ports',
       contentComp: (
-        <>
-          <p>
-            It wasn’t just ground transportation in Los Angeles that was affected by COVID-related shutdowns – its ports also showed less activity. During the pandemic, supply chains around the world dependent on cargo shipping saw interruptions as many ports closed, shipments canceled, and in some locations, altered routes prevented the efficient movement of cargo. According to the Port of Los Angeles, its port saw a 19% reduction in shipping cargo volume during the early months of the pandemic, compared to the same time period in 2019. The image here shows a reduction in the number of ships at the port, which could potentially also affect the area’s overall water quality.
-          </p>
-          <MapLayerLegend>
-            <Heading as='h2' size='medium'>
-              About the data
-            </Heading>
-            <p>
-              Ships detected in PlanetScope imagery are shown in orange.
-            </p>
-          </MapLayerLegend>
-        </>
+        <p>
+          It wasn’t just ground transportation in Los Angeles that was affected by COVID-related shutdowns – its ports also showed less activity. During the pandemic, supply chains around the world dependent on cargo shipping saw interruptions as many ports closed, shipments canceled, and in some locations, altered routes prevented the efficient movement of cargo. According to the Port of Los Angeles, its port saw a 19% reduction in shipping cargo volume during the early months of the pandemic, compared to the same time period in 2019. The image here shows a reduction in the number of ships at the port, which could potentially also affect the area’s overall water quality.
+        </p>
       ),
       visual: {
         type: 'map-layer',
+        about: (
+          <LayerInfo>
+            <p>Ships detected in PlanetScope imagery are shown in orange.</p>
+          </LayerInfo>
+        ),
         data: {
           // bbox: [-118.6759, 33.4267, -117.0733, 34.3439],
           spotlight: 'la',
@@ -130,22 +107,17 @@ export default {
       id: 'changes-in-urban-heat',
       name: 'Changes in Urban Heat During Bay Area Shelter-In-Place Orders',
       contentComp: (
-        <>
-          <p>
-            Sudden changes in surface transportation may also be changing how cities trap and emit heat. Satellite and thermal data from the joint NASA-U.S. Geological Survey Landsat satellite and NASA’s ECOsystem Spaceborne Thermal Radiometer Experiment on Space Station (ECOSTRESS) instrument aboard the International Space Station show decreases in air pollution and the prevalence of empty parking lots changed how much solar radiation is absorbed and reflected from ground surfaces during the pandemic. In March, surface traffic in the San Francisco Bay Area dropped by 70%. Scientists found that the reduction in traffic corresponded to a 30% decrease in fine particulate and ozone pollution when compared to previous years.
-          </p>
-          <MapLayerLegend>
-            <Heading as='h2' size='medium'>
-              About the data
-            </Heading>
-            <p>
-              Slowdown Proxy Maps show areas with the greatest reduction in car activity shaded in blue. Darker blues indicate areas of greater change.
-            </p>
-          </MapLayerLegend>
-        </>
+        <p>
+          Sudden changes in surface transportation may also be changing how cities trap and emit heat. Satellite and thermal data from the joint NASA-U.S. Geological Survey Landsat satellite and NASA’s ECOsystem Spaceborne Thermal Radiometer Experiment on Space Station (ECOSTRESS) instrument aboard the International Space Station show decreases in air pollution and the prevalence of empty parking lots changed how much solar radiation is absorbed and reflected from ground surfaces during the pandemic. In March, surface traffic in the San Francisco Bay Area dropped by 70%. Scientists found that the reduction in traffic corresponded to a 30% decrease in fine particulate and ozone pollution when compared to previous years.
+        </p>
       ),
       visual: {
         type: 'map-layer',
+        about: (
+          <LayerInfo>
+            <p>Slowdown Proxy Maps show areas with the greatest reduction in car activity shaded in blue. Darker blues indicate areas of greater change.</p>
+          </LayerInfo>
+        ),
         data: {
           bbox: [-122.2635, 37.6967, -122.1492, 37.7507],
           spotlight: 'sf',

--- a/app/assets/scripts/components/stories/story-water.js
+++ b/app/assets/scripts/components/stories/story-water.js
@@ -1,17 +1,9 @@
 import React from 'react';
-import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 
-import Heading from '../../styles/type/heading';
-import { glsp } from '../../styles/utils/theme-values';
-
 import config from '../../config';
+import { LayerInfo } from './single/about-data';
 const { api } = config;
-
-const MapLayerLegend = styled.div`
-  display: grid;
-  grid-gap: ${glsp(0.5)};
-`;
 
 export default {
   id: 'water-quality',
@@ -163,22 +155,17 @@ export default {
       id: 'counting-crops',
       name: 'Counting Crops During a Lockdown',
       contentComp: (
-        <>
-          <p>
-            CEarth-observing satellites have been critical to filling in information about crop planting and conditions, particularly where social distancing and shutdowns have made it difficult to collect ground data. NASA Harvest researchers at the University of Maryland in College Park are using data from U.S. and European satellites to supplement data collected on the ground by the U.S. Department of Agriculture. Using satellite data and machine learning, the researchers are monitoring key commodity crops that have high impacts on markets and food security, including corn and soybeans in the U.S. (pictured here) and winter wheat in Russia.
-          </p>
-          <MapLayerLegend>
-            <Heading as='h2' size='medium'>
-              About the data
-            </Heading>
-            <p>
-              Landsat-8, visualized using the agriculture band combination (6, 5, 2).
-            </p>
-          </MapLayerLegend>
-        </>
+        <p>
+          CEarth-observing satellites have been critical to filling in information about crop planting and conditions, particularly where social distancing and shutdowns have made it difficult to collect ground data. NASA Harvest researchers at the University of Maryland in College Park are using data from U.S. and European satellites to supplement data collected on the ground by the U.S. Department of Agriculture. Using satellite data and machine learning, the researchers are monitoring key commodity crops that have high impacts on markets and food security, including corn and soybeans in the U.S. (pictured here) and winter wheat in Russia.
+        </p>
       ),
       visual: {
         type: 'map-layer',
+        about: (
+          <LayerInfo>
+            <p>Landsat-8, visualized using the agriculture band combination (6, 5, 2).</p>
+          </LayerInfo>
+        ),
         data: {
           bbox: [-93.7916, 41.5923, -92.9731, 42.0248],
           mapLabel: 'March 4, 2020',
@@ -266,18 +253,15 @@ export default {
               Learn More About Changing Human Behavior During the COVID-19 Pandemic
             </Link>
           </p>
-          <MapLayerLegend>
-            <Heading as='h2' size='medium'>
-              About the data
-            </Heading>
-            <p>
-              Landsat-8, visualized using the bathymetric band combination (4,3,1).
-            </p>
-          </MapLayerLegend>
         </>
       ),
       visual: {
         type: 'map-layer',
+        about: (
+          <LayerInfo>
+            <p>Landsat-8, visualized using the bathymetric band combination (4,3,1).</p>
+          </LayerInfo>
+        ),
         data: {
           bbox: [-89.9533, 16.5, -87.2012, 18.2],
           mapLabel: () => 'March 3, 2020',


### PR DESCRIPTION
Funny little bug you found here @olafveerman.

There was no support for changing tiles of raster sources. This was because until now we only had to change tiles to have different dates and in that case you'd use a `raster-timeseries` type and not a `raster`.

In this case the layer id was also the same (spotlight id is not taken into consideration for layer swapping) so the map would hide/show the layer and not remove/add it.
Fix was easy and now if the tile source is different it gets replaced.

Additionally I made some tweaks to the legend. The formatting was a bit off and having custom styles for it was more problematic that fixing the legend.
You now have an `about` field, where you can add anything you want printed in the "About the data" section. This will be added after any legend the layers have.
```diff
 visual: {
   type: 'map-layer',
+  about: (
+    <LayerInfo>
+      <p>Ships detected in PlanetScope imagery are shown in orange.</p>
+    </LayerInfo>
+  ),
   data: {
     spotlight: 'la',
     mapLabel: () => 'March 11, 2020',
     date: '2020-03-11T00:00:00Z',
     layers: ['detections-ship']
   }
 }
```

The `LayerInfo` component just sets some font styles and add the `i` icon. You can import it from `/components/stories/single/about-data.js`;

![image](https://user-images.githubusercontent.com/1090606/101187642-87e0c080-364c-11eb-8868-6e0b70e03427.png)
