### PR TITLE
Fix WQ story

### DIFF
--- a/app/assets/scripts/components/indicators/indicator-co2.js
+++ b/app/assets/scripts/components/indicators/indicator-co2.js
@@ -256,7 +256,7 @@ class CO2LongForm extends React.Component {
                 To track the changes in atmospheric CO<sub>2</sub> during
                 COVID-19 shutdowns, researchers are using observations from the{' '}
                 <a
-                  href='https://oco.jpl.nasa.gov/'
+                  href='https://ocov2.jpl.nasa.gov/'
                   target='_blank'
                   rel='noopener noreferrer'
                 >
@@ -366,7 +366,7 @@ class CO2LongForm extends React.Component {
               <ul>
                 <li>
                   <a
-                    href='https://oco.jpl.nasa.gov/'
+                    href='https://ocov2.jpl.nasa.gov/'
                     target='_blank'
                     rel='noopener noreferrer'
                   >

--- a/app/assets/scripts/components/stories/story-water.js
+++ b/app/assets/scripts/components/stories/story-water.js
@@ -110,9 +110,9 @@ export default {
       visual: {
         type: 'map-layer',
         data: {
-          layers: ['water-wq-gl-chl'],
-          mapLabel: 'April 1, 2020',
-          date: '2020-04-01T00:00:00Z',
+          layers: ['water-chlorophyll'],
+          mapLabel: 'March 31, 2020',
+          date: '2020-03-31T00:00:00Z',
           spotlight: 'gl',
           bbox: [-84.3695, 45.2013, -81.7492, 41.253]
         }


### PR DESCRIPTION
Data for Great Lakes is missing from WQ story, and crashes the site. This should fix it.
Depends on: https://github.com/NASA-IMPACT/covid-api/pull/118